### PR TITLE
Upgrade to 2.1.0 Final and remove workaround for THORN-2015

### DIFF
--- a/microprofile/microprofile-config-1.1/pom.xml
+++ b/microprofile/microprofile-config-1.1/pom.xml
@@ -20,13 +20,6 @@
         <dependency>
             <groupId>io.thorntail</groupId>
             <artifactId>microprofile-config</artifactId>
-            <!-- workaround for https://issues.jboss.org/browse/THORN-2015 -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.swarm</groupId>
-                    <artifactId>config-api-runtime</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.thorntail</groupId>

--- a/microprofile/microprofile-config-1.1/src/main/resources/project-defaults.yml
+++ b/microprofile/microprofile-config-1.1/src/main/resources/project-defaults.yml
@@ -3,6 +3,9 @@ swarm:
     config:
       config-sources:
         default:
+          # ordinal defaults to 100, which collides with microprofile-config.properties,
+          # and selecting between config sources with the same ordinal is random
+          ordinal: 101
           dir: ${project.build.directory}/classes/configs
         propertiesSource:
           properties:

--- a/microprofile/microprofile-config-1.2/pom.xml
+++ b/microprofile/microprofile-config-1.2/pom.xml
@@ -20,13 +20,6 @@
         <dependency>
             <groupId>io.thorntail</groupId>
             <artifactId>microprofile-config</artifactId>
-            <!-- workaround for https://issues.jboss.org/browse/THORN-2015 -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.swarm</groupId>
-                    <artifactId>config-api-runtime</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.thorntail</groupId>

--- a/microprofile/microprofile-fault-tolerance-1.0/pom.xml
+++ b/microprofile/microprofile-fault-tolerance-1.0/pom.xml
@@ -20,13 +20,6 @@
         <dependency>
             <groupId>io.thorntail</groupId>
             <artifactId>microprofile-fault-tolerance</artifactId>
-            <!-- workaround for https://issues.jboss.org/browse/THORN-2015 -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.swarm</groupId>
-                    <artifactId>config-api-runtime</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.thorntail</groupId>

--- a/microprofile/microprofile-health-check-1.0/pom.xml
+++ b/microprofile/microprofile-health-check-1.0/pom.xml
@@ -20,13 +20,6 @@
         <dependency>
             <groupId>io.thorntail</groupId>
             <artifactId>microprofile-health</artifactId>
-            <!-- workaround for https://issues.jboss.org/browse/THORN-2015 -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.swarm</groupId>
-                    <artifactId>config-api-runtime</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/microprofile/microprofile-jwt-1.0/pom.xml
+++ b/microprofile/microprofile-jwt-1.0/pom.xml
@@ -20,13 +20,6 @@
         <dependency>
             <groupId>io.thorntail</groupId>
             <artifactId>microprofile-jwt</artifactId>
-            <!-- workaround for https://issues.jboss.org/browse/THORN-2015 -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.swarm</groupId>
-                    <artifactId>config-api-runtime</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/microprofile/microprofile-jwt-1.0/src/test/java/org/wildfly/swarm/ts/microprofile/jwt/v10/AbstractMicroProfileJwt10Test.java
+++ b/microprofile/microprofile-jwt-1.0/src/test/java/org/wildfly/swarm/ts/microprofile/jwt/v10/AbstractMicroProfileJwt10Test.java
@@ -244,7 +244,6 @@ public abstract class AbstractMicroProfileJwt10Test {
         assertThat(response).isEqualTo("Hello, world!");
     }
 
-    @Ignore("SWARM-1955")
     @Test
     @RunAsClient
     public void contentTypes_plain_webGroup() throws IOException, GeneralSecurityException {
@@ -265,7 +264,6 @@ public abstract class AbstractMicroProfileJwt10Test {
         assertThat(response).isEqualTo("<html>Hello, world!</html>");
     }
 
-    @Ignore("SWARM-1955")
     @Test
     @RunAsClient
     public void contentTypes_web_plainGroup() throws IOException, GeneralSecurityException {
@@ -283,7 +281,6 @@ public abstract class AbstractMicroProfileJwt10Test {
         assertThat(response).isEqualTo("Admin accessed foo");
     }
 
-    @Ignore("SWARM-1972")
     @Test
     @RunAsClient
     public void parameterizedPaths_admin_viewGroup() throws IOException, GeneralSecurityException {
@@ -298,7 +295,6 @@ public abstract class AbstractMicroProfileJwt10Test {
         assertThat(response).isEqualTo("View accessed foo");
     }
 
-    @Ignore("SWARM-1972")
     @Test
     @RunAsClient
     public void parameterizedPaths_view_adminGroup() throws IOException, GeneralSecurityException {

--- a/microprofile/microprofile-metrics-1.0/pom.xml
+++ b/microprofile/microprofile-metrics-1.0/pom.xml
@@ -20,13 +20,6 @@
         <dependency>
             <groupId>io.thorntail</groupId>
             <artifactId>microprofile-metrics</artifactId>
-            <!-- workaround for https://issues.jboss.org/browse/THORN-2015 -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.swarm</groupId>
-                    <artifactId>config-api-runtime</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.thorntail</groupId>

--- a/microprofile/microprofile-metrics-1.1/pom.xml
+++ b/microprofile/microprofile-metrics-1.1/pom.xml
@@ -24,13 +24,6 @@
         <dependency>
             <groupId>io.thorntail</groupId>
             <artifactId>microprofile-metrics</artifactId>
-            <!-- workaround for https://issues.jboss.org/browse/THORN-2015 -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.swarm</groupId>
-                    <artifactId>config-api-runtime</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/microprofile/microprofile-openapi-1.0/pom.xml
+++ b/microprofile/microprofile-openapi-1.0/pom.xml
@@ -20,14 +20,6 @@
         <dependency>
             <groupId>io.thorntail</groupId>
             <artifactId>microprofile-openapi</artifactId>
-            <version>${version.io.thorntail}</version> <!-- TODO remove with 2.1.0.Final, the fraction is 'experimental' in 2.0.0.Final -->
-            <!-- workaround for https://issues.jboss.org/browse/THORN-2015 -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.swarm</groupId>
-                    <artifactId>config-api-runtime</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/microprofile/microprofile-opentracing-1.0/pom.xml
+++ b/microprofile/microprofile-opentracing-1.0/pom.xml
@@ -19,33 +19,17 @@
     <dependencies>
         <dependency>
             <groupId>io.thorntail</groupId>
+            <artifactId>jaeger</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.thorntail</groupId>
             <artifactId>microprofile-opentracing</artifactId>
-            <version>${version.io.thorntail}</version> <!-- TODO remove with 2.1.0.Final, the fraction is 'experimental' in 2.0.0.Final -->
-            <!-- workaround for https://issues.jboss.org/browse/THORN-2015 -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.swarm</groupId>
-                    <artifactId>config-api-runtime</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.thorntail</groupId>
             <artifactId>undertow</artifactId>
         </dependency>
 
-        <!-- TODO remove with 2.1.0.Final and instead add the jaeger fraction -->
-        <dependency>
-            <groupId>io.jaegertracing</groupId>
-            <artifactId>jaeger-tracerresolver</artifactId>
-            <version>${version.io.jaegertracing.everything}</version>
-       </dependency>
-
-        <dependency>
-            <groupId>io.thorntail</groupId>
-            <artifactId>arquillian</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -101,16 +85,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <!-- TODO remove with 2.1.0.Final -->
-                <configuration>
-                    <environmentVariables>
-                        <!-- https://www.jaegertracing.io/docs/client-features/ -->
-                        <JAEGER_SERVICE_NAME>test-traced-service</JAEGER_SERVICE_NAME>
-                        <!-- https://www.jaegertracing.io/docs/sampling/ -->
-                        <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
-                        <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
-                    </environmentVariables>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/microprofile/microprofile-rest-client-1.0/pom.xml
+++ b/microprofile/microprofile-rest-client-1.0/pom.xml
@@ -20,13 +20,6 @@
         <dependency>
             <groupId>io.thorntail</groupId>
             <artifactId>microprofile-restclient</artifactId>
-            <!-- workaround for https://issues.jboss.org/browse/THORN-2015 -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.swarm</groupId>
-                    <artifactId>config-api-runtime</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.thorntail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <version.io.fabric8.docker-maven-plugin>0.25.2</version.io.fabric8.docker-maven-plugin>
         <version.io.jaegertracing.everything>0.27.0</version.io.jaegertracing.everything>
         <version.io.jsonwebtoken.jjwt>0.9.0</version.io.jsonwebtoken.jjwt>
-        <version.io.thorntail>2.0.0.Final</version.io.thorntail>
+        <version.io.thorntail>2.1.0.Final</version.io.thorntail>
         <version.javax.enterprise.cdi-api>1.2</version.javax.enterprise.cdi-api>
         <version.junit.junit>4.12</version.junit.junit>
         <version.net.java.xadisk>1.2.2</version.net.java.xadisk>
@@ -184,12 +184,6 @@ remove this line for EAP Client BOMs -->
                 <type>pom</type>
             </dependency>
 
-             <!-- workaround for https://issues.jboss.org/browse/THORN-2015 for running Arquillian tests -->
-            <dependency>
-                <groupId>org.wildfly.swarm</groupId>
-                <artifactId>config-api-runtime</artifactId>
-                <version>1.3.1</version>
-            </dependency>
 <!-- remove this line for bom-certified
             <dependency>
                 <groupId>io.thorntail</groupId>


### PR DESCRIPTION
The new "ordinal" attribute makes sense, as microprofile-config.properties takes precedence unless giving a higher value than 100 (same behavior with yamlOrderedProperty). So they fixed that in smallrye.