### PR TITLE
improve Secured Ribbon test

### DIFF
--- a/netflix/ribbon-secured/src/main/resources/META-INF/services/org.jboss.msc.service.ServiceActivator
+++ b/netflix/ribbon-secured/src/main/resources/META-INF/services/org.jboss.msc.service.ServiceActivator
@@ -1,0 +1,1 @@
+org.wildfly.swarm.ts.netflix.ribbon.secured.MockTopologyConnectorServiceActivator

--- a/netflix/ribbon-secured/src/main/resources/project-defaults.yml
+++ b/netflix/ribbon-secured/src/main/resources/project-defaults.yml
@@ -1,0 +1,42 @@
+swarm:
+  keycloak:
+    secure-deployments:
+      # for the Arquillian test
+      RibbonSecuredTopologyIT.war:
+        auth-server-url: "http://localhost:8180/auth"
+        realm: test-realm
+        resource: test-client
+        credentials:
+          secret:
+            value: 19666a4f-32dd-4049-b082-684c74115f28
+      # for the actual uberjar
+      ts-netflix-ribbon-secured-1.0.0-SNAPSHOT.war:
+        auth-server-url: "http://localhost:8180/auth"
+        realm: test-realm
+        resource: test-client
+        credentials:
+          secret:
+            value: 19666a4f-32dd-4049-b082-684c74115f28
+  deployment:
+    # for the Arquillian test
+    RibbonSecuredTopologyIT.war:
+      ribbon:
+        advertise: ts-netflix-ribbon-secured
+      web:
+        security-constraints:
+        - url-pattern: /hello
+          methods:
+          - GET
+          roles:
+          - "*"
+    # for the actual uberjar
+    ts-netflix-ribbon-secured-1.0.0-SNAPSHOT.war:
+      ribbon:
+        advertise: ts-netflix-ribbon-secured
+      web:
+        security-constraints:
+        - url-pattern: /hello
+          methods:
+          - GET
+          roles:
+          - "*"

--- a/netflix/ribbon-secured/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/netflix/ribbon-secured/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!-- this file only exists for manual tests; RibbonSecuredTopologyIT uses @DeploymentModule -->
+<jboss-deployment-structure>
+    <deployment>
+        <dependencies>
+            <!-- needed for mock topology connector -->
+            <module name="org.wildfly.swarm.topology" slot="runtime"/>
+            <module name="org.jboss.as.network"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>


### PR DESCRIPTION
THORN-1921 fixed an issue that caused Secured Ribbon to only be
usable with custom `main`. Since custom `main` is deprecated,
this commit changes the Secured Ribbon test to no longer use
an Arquillian `@Deployment` method, which essentially contained
equivalent of the required custom `main`. Instead, the test
now uses `@DefaultDeployment` and YAML configuration.