### PR TITLE
Keep as similar as possible as all-in-one docs example

### DIFF
--- a/microprofile/microprofile-opentracing-1.0/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/v10/MicroProfileOpenTracing10Test.java
+++ b/microprofile/microprofile-opentracing-1.0/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/v10/MicroProfileOpenTracing10Test.java
@@ -38,8 +38,8 @@ public class MicroProfileOpenTracing10Test {
                 .port("5778:5778")
                 .port("16686:16686")
                 .port("14268:14268")
-                .port("14250:14250")
                 .port("9411:9411")
+                .envVar("COLLECTOR_ZIPKIN_HTTP_PORT", "9411")
                 .start();
     }
 

--- a/microprofile/opentracing-restclient/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/restclient/MicroProfileOpenTracingRestClientTest.java
+++ b/microprofile/opentracing-restclient/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/restclient/MicroProfileOpenTracingRestClientTest.java
@@ -38,8 +38,8 @@ public class MicroProfileOpenTracingRestClientTest {
                 .port("5778:5778")
                 .port("16686:16686")
                 .port("14268:14268")
-                .port("14250:14250")
                 .port("9411:9411")
+                .envVar("COLLECTOR_ZIPKIN_HTTP_PORT", "9411")
                 .start();
     }
 

--- a/opentracing/basic/src/test/java/org/wildfly/swarm/ts/opentracing/basic/OpenTracingBasicTest.java
+++ b/opentracing/basic/src/test/java/org/wildfly/swarm/ts/opentracing/basic/OpenTracingBasicTest.java
@@ -38,8 +38,8 @@ public class OpenTracingBasicTest {
                 .port("5778:5778")
                 .port("16686:16686")
                 .port("14268:14268")
-                .port("14250:14250")
                 .port("9411:9411")
+                .envVar("COLLECTOR_ZIPKIN_HTTP_PORT", "9411")
                 .start();
     }
 

--- a/opentracing/jaeger/src/test/java/org/wildfly/swarm/ts/opentracing/jaeger/OpenTracingJaegerTest.java
+++ b/opentracing/jaeger/src/test/java/org/wildfly/swarm/ts/opentracing/jaeger/OpenTracingJaegerTest.java
@@ -38,8 +38,8 @@ public class OpenTracingJaegerTest {
                 .port("5778:5778")
                 .port("16686:16686")
                 .port("14268:14268")
-                .port("14250:14250")
                 .port("9411:9411")
+                .envVar("COLLECTOR_ZIPKIN_HTTP_PORT", "9411")
                 .start();
     }
 


### PR DESCRIPTION
Let's try to keep as similar as this docs: https://www.jaegertracing.io/docs/1.11/getting-started/#all-in-one
Hopefully we gain some stability (which is bad now).
Works for me.