### PR TITLE
THORN-2356: MP OpenTracing13: tracing, logging, on interface, 2wildca…

### DIFF
--- a/microprofile/microprofile-opentracing-1.3/pom.xml
+++ b/microprofile/microprofile-opentracing-1.3/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.thorntail.ts</groupId>
+        <artifactId>ts-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>ts-microprofile-opentracing-1.3</artifactId>
+    <packaging>war</packaging>
+
+    <name>Thorntail TS: MicroProfile OpenTracing 1.3</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>jaeger</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>jaxrs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>microprofile-opentracing</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>arquillian</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.thorntail.ts</groupId>
+            <artifactId>ts-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/microprofile/microprofile-opentracing-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/opentracing/v13/Resource.java
+++ b/microprofile/microprofile-opentracing-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/opentracing/v13/Resource.java
@@ -1,0 +1,68 @@
+package org.wildfly.swarm.ts.microprofile.opentracing.v13;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+public class Resource {
+    @Inject
+    private TracedService service;
+
+    @GET
+    @Path("/tracedlogged")
+    public Response tracedLoggedMethod() {
+        return Response.ok().entity(service.tracedLoggedMethod()).build();
+    }
+
+    @GET
+    @Path("/traced")
+    public Response tracedMethod() {
+        return Response.ok().entity(service.tracedMethod()).build();
+    }
+
+    @GET
+    @Path("/logged")
+    public Response loggedMethod() {
+        return Response.ok().entity(service.loggedMethod()).build();
+    }
+
+    @GET
+    @Path("/nottracednotlogged")
+    public Response notTracedNotLoggedMethod() {
+        return Response.ok().entity(service.notTracedNotLoggedMethod()).build();
+    }
+
+    @GET
+    @Path("/named/true")
+    public Response tracedNamedTrue() {
+        return Response.ok().entity(service.tracedNamedTrue()).build();
+    }
+
+    @GET
+    @Path("/true")
+    public Response tracedTrue() {
+        return Response.ok().entity(service.tracedTrue()).build();
+    }
+
+    @GET
+    @Path("/named/false")
+    public Response tracedNamedFalse() {
+        return Response.ok().entity(service.tracedNamedFalse()).build();
+    }
+
+    @GET
+    @Path("/false")
+    public Response tracedFalse() {
+        return Response.ok().entity(service.tracedFalse()).build();
+    }
+
+    // Clarify http-path when path contains regular expressions (#136: https://github.com/eclipse/microprofile-opentracing/pull/136)
+    @GET
+    @Path("/test/{id: \\d+}/{txt: \\w+}")
+    public Response twoWildcard(@PathParam("id") long id, @PathParam("txt") String txt) {
+        return Response.ok().entity(service.twoWildcard(id, txt)).build();
+    }
+}

--- a/microprofile/microprofile-opentracing-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/opentracing/v13/RestApplication.java
+++ b/microprofile/microprofile-opentracing-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/opentracing/v13/RestApplication.java
@@ -1,0 +1,8 @@
+package org.wildfly.swarm.ts.microprofile.opentracing.v13;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/rest")
+public class RestApplication extends Application {
+}

--- a/microprofile/microprofile-opentracing-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/opentracing/v13/TracedService.java
+++ b/microprofile/microprofile-opentracing-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/opentracing/v13/TracedService.java
@@ -1,0 +1,66 @@
+package org.wildfly.swarm.ts.microprofile.opentracing.v13;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.opentracing.Tracer;
+import org.eclipse.microprofile.opentracing.Traced;
+
+@ApplicationScoped
+public class TracedService {
+    @Inject
+    private Tracer tracer;
+
+    // 4 combinations of traced and logged
+    @Traced
+    public String tracedLoggedMethod() {
+        tracer.activeSpan().log("tracer: tracedLoggedMethod");
+        return "Hello from tracedLoggedMethod";
+    }
+
+    @Traced
+    public String tracedMethod() {
+        return "Hello from tracedMethod";
+    }
+
+    public String loggedMethod() {
+        tracer.activeSpan().log("tracer: loggedMethod");
+        return "Hello from loggedMethod";
+    }
+
+    public String notTracedNotLoggedMethod() {
+        return "Hello from notTracedNotLoggedMethod";
+    }
+
+    // combinations of @Traced attributes: value and operationName
+    @Traced(true)
+    public String tracedTrue() {
+        tracer.activeSpan().log("tracedTrue");
+        return "Hello from tracedTrue";
+    }
+
+    @Traced(value = true, operationName = "operationName-should-appear-tracedNamedTrue")
+    public String tracedNamedTrue() {
+        tracer.activeSpan().log("tracedNamedTrue");
+        return "Hello from tracedNamedTrue";
+    }
+
+    @Traced(false)
+    public String tracedFalse() {
+        tracer.activeSpan().log("tracedFalse");
+        return "Hello from tracedFalse";
+    }
+
+    @Traced(value = false, operationName = "should-not-appear-tracedNamedFalse")
+    public String tracedNamedFalse() {
+        tracer.activeSpan().log("tracedNamedFalse");
+        return "Hello from tracedNamedFalse";
+    }
+
+    // two wild cards
+    @Traced
+    public String twoWildcard(long id, String txt) {
+        tracer.activeSpan().log("twoWildcard: " + id + ", " + txt);
+        return "Hello from twoWildcard: " + id + ", " + txt;
+    }
+}

--- a/microprofile/microprofile-opentracing-1.3/src/main/resources/project-defaults.yml
+++ b/microprofile/microprofile-opentracing-1.3/src/main/resources/project-defaults.yml
@@ -1,0 +1,5 @@
+thorntail:
+  jaeger:
+    service-name: test-traced-service
+    sampler-type: const
+    sampler-parameter: 1

--- a/microprofile/microprofile-opentracing-1.3/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/v13/MPOpenTracing13Test.java
+++ b/microprofile/microprofile-opentracing-1.3/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/v13/MPOpenTracing13Test.java
@@ -1,0 +1,204 @@
+package org.wildfly.swarm.ts.microprofile.opentracing.v13;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.http.client.fluent.Request;
+import org.assertj.core.api.Assertions;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+import org.wildfly.swarm.ts.common.docker.Docker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class MPOpenTracing13Test {
+    private static final String PREFIX = "org.wildfly.swarm.ts.microprofile.opentracing.v13.";
+
+    private static final String GET_PREFIX = "GET:" + PREFIX;
+
+    private static final String URL_REST = "http://localhost:8080/rest/";
+
+    private ImmutableMap<String, String> URL_TO_RESPONSES = ImmutableMap.<String, String>builder()
+            .put("tracedlogged", "Hello from tracedLoggedMethod")
+            .put("traced", "Hello from tracedMethod")
+            .put("logged", "Hello from loggedMethod")
+            .put("nottracednotlogged", "Hello from notTracedNotLoggedMethod")
+
+            .put("named/true", "Hello from tracedNamedTrue")
+            .put("true", "Hello from tracedTrue")
+            .put("named/false", "Hello from tracedNamedFalse")
+            .put("false", "Hello from tracedFalse")
+            // test http-path when path contains regular expressions (#136)
+            .put("test/1/hello", "Hello from twoWildcard: 1, hello")
+            .build();
+
+    private List<Trace> EXPECTED_TRACES = Arrays.asList(
+            // traced and tracer.span.logging combinations
+            new Trace("Resource.tracedLoggedMethod", null, PREFIX + "TracedService.tracedLoggedMethod", "tracer: tracedLoggedMethod"),
+            new Trace("Resource.tracedMethod", null, PREFIX + "TracedService.tracedMethod", null),
+            new Trace("Resource.loggedMethod", "tracer: loggedMethod"),
+            new Trace("Resource.notTracedNotLoggedMethod"),
+            // operationName with on/off combination
+            new Trace("Resource.tracedNamedTrue", null, "operationName-should-appear-tracedNamedTrue", "tracedNamedTrue"),
+            new Trace("Resource.tracedTrue", null, PREFIX + "TracedService.tracedTrue", "tracedTrue"),
+            new Trace("Resource.tracedNamedFalse", "tracedNamedFalse"),
+            new Trace("Resource.tracedFalse", "tracedFalse"),
+            // two wild cards
+            new Trace("Resource.twoWildcard", null, PREFIX + "TracedService.twoWildcard", "twoWildcard: 1, hello")
+    );
+
+    @ClassRule
+    public static Docker jaegerContainer = new Docker("jaeger", "jaegertracing/all-in-one:latest")
+            .waitForLogLine("\"Health Check state change\",\"status\":\"ready\"")
+            // https://www.jaegertracing.io/docs/1.11/getting-started/
+            .port("5775:5775/udp")
+            .port("6831:6831/udp")
+            .port("6832:6832/udp")
+            .port("5778:5778")
+            .port("16686:16686")
+            .port("14250:14250")
+            .port("14267:14267")
+            .port("14268:14268")
+            .port("9411:9411")
+            .envVar("COLLECTOR_ZIPKIN_HTTP_PORT", "9411")
+            .cmdArg("--reporter.grpc.host-port=localhost:14250");
+
+    @Test
+    @InSequence(1)
+    @RunAsClient
+    public void applicationRequest() {
+        URL_TO_RESPONSES.forEach((url, expectedResponse) -> {
+            try {
+                assertThat(Request.Get(URL_REST + url).execute().returnContent().asString())
+                        .isEqualTo(expectedResponse);
+            } catch (IOException e) {
+                Assertions.fail("IOException occurred for url: " + URL_REST + url +
+                                        ", when expecting: \"" + expectedResponse + "\": " + e.getMessage());
+            }
+        });
+    }
+
+    @Test
+    @InSequence(2)
+    @RunAsClient
+    public void trace() {
+        // the tracer inside the application doesn't send traces to the Jaeger server immediately,
+        // they are batched, so we need to wait a bit
+        await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
+            String response = Request.Get("http://localhost:16686/api/traces?service=test-traced-service").execute().returnContent().asString();
+            JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+            assertThat(json.has("data")).isTrue();
+            JsonArray data = json.getAsJsonArray("data");
+
+            assertThat(data.size()).isEqualTo(EXPECTED_TRACES.size());
+
+            EXPECTED_TRACES.forEach(trace -> checkTrace(data,
+                                                        trace.getOperationName(),
+                                                        trace.getLog(),
+                                                        trace.getChildOperationName(),
+                                                        trace.getChildLog()));
+        });
+    }
+
+    private static void checkTrace(final JsonArray data, final String operationName, final String log,
+                                   final String childOperationName, final String childLog) {
+        assertThat(data).anySatisfy(element -> {
+            JsonObject elemObj = element.getAsJsonObject();
+            assertThat(elemObj.has("spans")).isTrue();
+            JsonArray spans = elemObj.getAsJsonArray("spans");
+            if (spans.size() == 1) {
+                JsonObject span = spans.get(0).getAsJsonObject();
+                // check operation name match
+                assertThat(span.get("operationName").getAsString()).isEqualTo(operationName);
+                // check log is empty or has desired value from tracer
+                checkLogPart(log, span);
+            } else if (spans.size() == 2) {
+                if (childOperationName != null) {
+                    JsonObject span1 = spans.get(0).getAsJsonObject();
+                    JsonObject span2 = spans.get(1).getAsJsonObject();
+                    if (operationName.equals(span1.get("operationName").getAsString())) {
+                        checkLogPart(log, span1);
+                        // check child
+                        assertThat(childOperationName).isEqualTo(span2.get("operationName").getAsString());
+                        checkLogPart(childLog, span2);
+                    } else if (operationName.equals(span2.get("operationName").getAsString())) {
+                        checkLogPart(log, span2);
+                        // check child
+                        assertThat(childOperationName).isEqualTo(span1.get("operationName").getAsString());
+                        checkLogPart(childLog, span1);
+                    } else {
+                        Assertions.fail("Unable to find parent span with name: " + operationName);
+                    }
+                }
+            }
+        });
+    }
+
+    private static void checkLogPart(String log, JsonObject span) {
+        JsonArray logArray = span.get("logs").getAsJsonArray();
+        // there should be only 0 or 1 log included
+        if (log == null) {
+            assertThat(logArray.size()).isEqualTo(0);
+        } else {
+            assertThat(logArray.size()).isEqualTo(1);
+            String logValue = logArray.get(0).getAsJsonObject().getAsJsonArray("fields").get(0).getAsJsonObject().get("value").getAsString();
+            assertThat(logValue).isEqualTo(log);
+        }
+    }
+
+    private class Trace {
+        private String operationName;
+
+        private String log;
+
+        private String childOperationName;
+
+        private String childLog;
+
+        Trace(String operationName) {
+            new Trace(operationName, null);
+        }
+
+        Trace(String operationName, String log) {
+            new Trace(operationName, log, null, null);
+        }
+
+        Trace(String operationName, String log, String childOperationName, String childLog) {
+            this.operationName = GET_PREFIX + operationName;
+            this.log = log;
+            this.childOperationName = childOperationName;
+            this.childLog = childLog;
+
+        }
+
+        String getOperationName() {
+            return operationName;
+        }
+
+        String getLog() {
+            return log;
+        }
+
+        String getChildOperationName() {
+            return childOperationName;
+        }
+
+        String getChildLog() {
+            return childLog;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <module>microprofile/microprofile-openapi-1.0</module>
         <module>microprofile/microprofile-openapi-1.1</module>
         <module>microprofile/microprofile-opentracing-1.0</module>
+        <module>microprofile/microprofile-opentracing-1.3</module>
         <module>microprofile/microprofile-rest-client-1.0</module>
         <module>microprofile/microprofile-rest-client-1.2</module>
         <module>microprofile/opentracing-fault-tolerance</module>


### PR DESCRIPTION
…rds, operationName
Tests try to cover all possibilities of tracing. The annotation can be on method of service, on interface and on methods of interface. There also can be a tracer that is able to write a log into active span.
I didn't find effect of turning tracing off because GET calls are logged by default and descendants can override this option, therefore expected set of traces includes even calls to methods of interface with turned-off tracing annotation.