### PR TITLE
THORN-2418: MP Rest Client 1.3 autoCloseable, configKey

### DIFF
--- a/microprofile/microprofile-rest-client-1.3/pom.xml
+++ b/microprofile/microprofile-rest-client-1.3/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.thorntail.ts</groupId>
+        <artifactId>ts-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>ts-microprofile-rest-client-1.3</artifactId>
+    <packaging>war</packaging>
+
+    <name>Thorntail TS: MicroProfile Rest Client 1.3</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>jaxrs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>microprofile-restclient</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>arquillian</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/ClientAutoCloseable.java
+++ b/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/ClientAutoCloseable.java
@@ -1,0 +1,13 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v13;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey="myClientsKey")
+public interface ClientAutoCloseable extends AutoCloseable {
+    @GET
+    @Path("/rest/simple")
+    String simpleOperation();
+}

--- a/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/ClientCloseable.java
+++ b/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/ClientCloseable.java
@@ -1,0 +1,15 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v13;
+
+import java.io.Closeable;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey="myClientsKey")
+public interface ClientCloseable extends Closeable {
+    @GET
+    @Path("/rest/simple")
+    String simpleOperation();
+}

--- a/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/ClientMissingKey.java
+++ b/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/ClientMissingKey.java
@@ -1,0 +1,13 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v13;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey="missingKey")
+public interface ClientMissingKey extends AutoCloseable {
+    @GET
+    @Path("/rest/simple")
+    String simpleOperation();
+}

--- a/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/RestApplication.java
+++ b/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/RestApplication.java
@@ -1,0 +1,8 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v13;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/rest")
+public class RestApplication extends Application {
+}

--- a/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/RestClientResource.java
+++ b/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/RestClientResource.java
@@ -1,0 +1,73 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v13;
+
+import java.net.URI;
+import java.net.URL;
+
+import javax.enterprise.inject.spi.CDI;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@Path("/client")
+public class RestClientResource {
+    private static final String HTTP_LOCALHOST_8080 = "http://localhost:8080";
+
+    @GET
+    @Path("/config-key")
+    public String configKey() {
+        ClientAutoCloseable client = CDI.current().select(ClientAutoCloseable.class, RestClient.LITERAL).get();
+        return client.simpleOperation();
+    }
+
+    @GET
+    @Path("/missing-config-key")
+    public String missingConfigKey() {
+        String result;
+        try {
+            ClientMissingKey client = CDI.current().select(ClientMissingKey.class, RestClient.LITERAL).get();
+            result = client.simpleOperation();
+        } catch (Exception e) {
+            result = e.getMessage(); // expecting "Neither baseUri nor baseUrl was specified"
+        }
+        return result;
+    }
+
+    @GET
+    @Path("/auto-close")
+    public String autoClose() throws Exception {
+        String response;
+        ClientAutoCloseable client = RestClientBuilder.newBuilder()
+                .baseUrl(new URL(HTTP_LOCALHOST_8080))
+                .build(ClientAutoCloseable.class);
+        try (ClientAutoCloseable c = client) {
+            response = c.simpleOperation();
+        }
+        // now client is auto-closed
+        try {
+            response += client.simpleOperation();
+        } catch (IllegalStateException e) {
+            response += ", client was auto-closed as expected.";
+        }
+        return response;
+    }
+
+    @GET
+    @Path("/manual-close")
+    public String close() throws Exception {
+        String response;
+        ClientCloseable client = RestClientBuilder.newBuilder()
+                .baseUri(new URI(HTTP_LOCALHOST_8080))
+                .build(ClientCloseable.class);
+        response = client.simpleOperation();
+        client.close();
+        // now client is closed
+        try {
+            response += client.simpleOperation();
+        } catch (IllegalStateException e) {
+            response += ", client was closed as expected.";
+        }
+        return response;
+    }
+}

--- a/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/SimpleResource.java
+++ b/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/SimpleResource.java
@@ -1,0 +1,15 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v13;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+public class SimpleResource {
+
+    @GET
+    @Path("/simple")
+    public Response simpleOperation() {
+        return Response.ok().entity("Hello from endpoint").build();
+    }
+}

--- a/microprofile/microprofile-rest-client-1.3/src/main/resources/META-INF/microprofile-config.properties
+++ b/microprofile/microprofile-rest-client-1.3/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,5 @@
+# "myClientsKey/mp-rest/uri" <--- will override all other links (nonsenseX)
+myClientsKey/mp-rest/uri=http://localhost:8080
+org.wildfly.swarm.ts.microprofile.rest.client.v13.ClientAutoCloseable/mp-rest/url=http://nonsense1
+myClientsKey/mp-rest/url=http://nonsense2
+#missingKey/mp-rest/uri=http://localhost:8080 -- expects test to fail on missing this configKey

--- a/microprofile/microprofile-rest-client-1.3/src/test/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/MicroprofileRestClient13Test.java
+++ b/microprofile/microprofile-rest-client-1.3/src/test/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/MicroprofileRestClient13Test.java
@@ -1,0 +1,46 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v13;
+
+import java.io.IOException;
+
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class MicroprofileRestClient13Test {
+
+    @Test
+    @RunAsClient
+    public void configKey() throws IOException {
+        String response = Request.Get("http://localhost:8080/rest/client/config-key").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello from endpoint");
+    }
+
+    @Test
+    @RunAsClient
+    public void missingConfigKey() throws IOException {
+        String response = Request.Get("http://localhost:8080/rest/client/missing-config-key").execute().returnContent().asString();
+        assertThat(response).contains("Neither baseUri nor baseUrl was specified");
+    }
+
+    @Test
+    @RunAsClient
+    public void closingOfClient() throws IOException {
+        String response = Request.Get("http://localhost:8080/rest/client/manual-close").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello from endpoint, client was closed as expected.");
+
+    }
+
+    @Test
+    @RunAsClient
+    public void autoClosingOfClient() throws IOException {
+        String response = Request.Get("http://localhost:8080/rest/client/auto-close").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello from endpoint, client was auto-closed as expected.");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <module>microprofile/microprofile-opentracing-1.3</module>
         <module>microprofile/microprofile-rest-client-1.0</module>
         <module>microprofile/microprofile-rest-client-1.2</module>
+        <module>microprofile/microprofile-rest-client-1.3</module>
         <module>microprofile/opentracing-fault-tolerance</module>
         <module>microprofile/opentracing-restclient</module>
 


### PR DESCRIPTION
A client instance can be closed by casting the instance to a Closeable or AutoCloseable.
It is possible to simplify configuration of client interfaces by using configuration key (e.g. "myClients").