### PR TITLE
THORN-2418: MP Rest Client 1.3 JSON as default MediaType for "@Produces/Consumes"

### DIFF
--- a/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/mediatype/ClientMediaType.java
+++ b/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/mediatype/ClientMediaType.java
@@ -1,0 +1,72 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v13.mediatype;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(baseUri = "http://localhost:8080")
+public interface ClientMediaType {
+    // @Produces
+
+    @GET
+    @Path("/rest/greetings-text")
+    String producesText_withoutAnnotation();
+
+    @GET
+    @Path("/rest/greetings-json")
+    String producesJson_withoutAnnotation();
+
+    @GET
+    @Path("/rest/greetings-xml")
+    String producesXml_withoutAnnotation();
+
+    @GET
+    @Produces
+    @Path("/rest/greetings-text")
+    String producesText_defaultAnnotationValue();
+
+    @GET
+    @Produces
+    @Path("/rest/greetings-json")
+    String producesJson_defaultAnnotationValue();
+
+    @GET
+    @Produces
+    @Path("/rest/greetings-xml")
+    String producesXml_defaultAnnotationValue();
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/rest/greetings-text")
+    String producesText_annotationValueTextPlain();
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/rest/greetings-json")
+    String producesJson_annotationValueTextPlain();
+
+    // @Consumes
+
+    @POST
+    @Path("/rest/consume-text")
+    String consumesText_withoutAnnotation(String text);
+
+    @POST
+    @Path("/rest/consume-json")
+    String consumesJson_withoutAnnotation(String text);
+
+    @POST
+    @Consumes
+    @Path("/rest/consume-text")
+    String consumesText_defaultAnnotationValue(String text);
+
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Path("/rest/consume-text")
+    String consumesText_annotationValueTextPlain(String text);
+}

--- a/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/mediatype/ResourceMediaType.java
+++ b/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/mediatype/ResourceMediaType.java
@@ -1,0 +1,56 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v13.mediatype;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/")
+public class ResourceMediaType {
+    public static final String GREETINGS_TEXT = "Greetings!";
+
+    public static final String GREETINGS_JSON = "{\"data\": \"Greetings!\"}";
+
+    public static final String GREETINGS_XML = "<data>Greetings!</data>";
+
+    // @Produces
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/greetings-text")
+    public String greetingsText() {
+        return GREETINGS_TEXT;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/greetings-json")
+    public String greetingsJson() {
+        return GREETINGS_JSON;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_XML)
+    @Path("/greetings-xml")
+    public String greetingsXml() {
+        return GREETINGS_XML;
+    }
+
+    // @Consumes
+
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Path("/consume-text")
+    public String consumeText(String content) {
+        return content;
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/consume-json")
+    public String consumeJson(String content) {
+        return content;
+    }
+}

--- a/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/mediatype/RestClientResource.java
+++ b/microprofile/microprofile-rest-client-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/mediatype/RestClientResource.java
@@ -1,0 +1,152 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v13.mediatype;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.function.Function;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+@Path("/")
+public class RestClientResource {
+    // @Produces
+
+    @GET
+    @Path("/producesText_withoutAnnotation")
+    public Response producesText_withoutAnnotation() {
+        try {
+            return response(ClientMediaType::producesText_withoutAnnotation);
+        } catch (Exception e) {
+            return errorResponse(e);
+        }
+    }
+
+    @GET
+    @Path("/producesJson_withoutAnnotation")
+    public Response producesJson_withoutAnnotation() {
+        try {
+            return response(ClientMediaType::producesJson_withoutAnnotation);
+        } catch (Exception e) {
+            return errorResponse(e);
+        }
+    }
+
+    @GET
+    @Path("/producesXml_withoutAnnotation")
+    public Response producesXml_withoutAnnotation() {
+        try {
+            return response(ClientMediaType::producesXml_withoutAnnotation);
+        } catch (Exception e) {
+            return errorResponse(e);
+        }
+    }
+
+    @GET
+    @Path("/producesText_defaultAnnotationValue")
+    public Response producesText_defaultAnnotationValue() {
+        try {
+            return response(ClientMediaType::producesText_defaultAnnotationValue);
+        } catch (Exception e) {
+            return errorResponse(e);
+        }
+    }
+
+    @GET
+    @Path("/producesJson_defaultAnnotationValue")
+    public Response producesJson_defaultAnnotationValue() {
+        try {
+            return response(ClientMediaType::producesJson_defaultAnnotationValue);
+        } catch (Exception e) {
+            return errorResponse(e);
+        }
+    }
+
+    @GET
+    @Path("/producesXml_defaultAnnotationValue")
+    public Response producesXml_defaultAnnotationValue() {
+        try {
+            return response(ClientMediaType::producesXml_defaultAnnotationValue);
+        } catch (Exception e) {
+            return errorResponse(e);
+        }
+    }
+
+    @GET
+    @Path("/producesText_annotationValueTextPlain")
+    public Response producesText_annotationValueTextPlain() {
+        try {
+            return response(ClientMediaType::producesText_annotationValueTextPlain);
+        } catch (Exception e) {
+            return errorResponse(e);
+        }
+    }
+
+    @GET
+    @Path("/producesJson_annotationValueTextPlain")
+    public Response producesJson_annotationValueTextPlain() {
+        try {
+            return response(ClientMediaType::producesJson_annotationValueTextPlain);
+        } catch (Exception e) {
+            return errorResponse(e);
+        }
+    }
+
+    // @Consumes
+
+    @GET
+    @Path("/consumesText_withoutAnnotation")
+    public Response consumesText_withoutAnnotation() {
+        try {
+            return response(client -> client.consumesText_withoutAnnotation(ResourceMediaType.GREETINGS_TEXT));
+        } catch (Exception e) {
+            return errorResponse(e);
+        }
+    }
+
+    @GET
+    @Path("/consumesJson_withoutAnnotation")
+    public Response consumesJson_withoutAnnotation() {
+        try {
+            return response(client -> client.consumesJson_withoutAnnotation(ResourceMediaType.GREETINGS_JSON));
+        } catch (Exception e) {
+            return errorResponse(e);
+        }
+    }
+
+    @GET
+    @Path("/consumesText_defaultAnnotationValue")
+    public Response consumesText_defaultAnnotationValue() {
+        try {
+            return response(client -> client.consumesText_defaultAnnotationValue(ResourceMediaType.GREETINGS_TEXT));
+        } catch (Exception e) {
+            return errorResponse(e);
+        }
+    }
+
+    @GET
+    @Path("/consumesText_annotationValueTextPlain")
+    public Response consumesText_annotationValueTextPlain() {
+        try {
+            return response(client -> client.consumesText_annotationValueTextPlain(ResourceMediaType.GREETINGS_TEXT));
+        } catch (Exception e) {
+            return errorResponse(e);
+        }
+    }
+
+    // ---
+
+    private Response response(Function<ClientMediaType, String> call) throws MalformedURLException {
+        ClientMediaType client = RestClientBuilder.newBuilder()
+                .baseUrl(new URL("http://localhost:8080"))
+                .build(ClientMediaType.class);
+        String result = call.apply(client);
+        return Response.ok().entity(result).build();
+    }
+
+    private Response errorResponse(Exception e) {
+        return Response.serverError().entity(e.getMessage()).build();
+    }
+}

--- a/microprofile/microprofile-rest-client-1.3/src/test/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/ProducesConsumesAnnotationsTest.java
+++ b/microprofile/microprofile-rest-client-1.3/src/test/java/org/wildfly/swarm/ts/microprofile/rest/client/v13/ProducesConsumesAnnotationsTest.java
@@ -1,0 +1,133 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v13;
+
+import java.io.IOException;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+import org.wildfly.swarm.ts.microprofile.rest.client.v13.mediatype.ResourceMediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class ProducesConsumesAnnotationsTest {
+    private static final String HTTP_REST = "http://localhost:8080/rest/";
+
+    private static final String EXPECTED_ERROR_406 = "Unknown error, status code 406";
+
+    private static final String EXPECTED_ERROR_415 = "Unknown error, status code 415";
+
+    // @Produces
+
+    // client without @Produces and resource with @Produces(MediaType.TEXT_PLAIN)
+    @Test
+    @RunAsClient
+    public void producesText_withoutAnnotation() throws IOException {
+        HttpResponse response = Request.Get(HTTP_REST + "producesText_withoutAnnotation").execute().returnResponse();
+        checkResponse(response, 500, EXPECTED_ERROR_406);
+    }
+
+    // client without @Produces and resource with @Produces(MediaType.APPLICATION_JSON)
+    @Test
+    @RunAsClient
+    public void producesJson_withoutAnnotation() throws IOException {
+        HttpResponse response = Request.Get(HTTP_REST + "producesJson_withoutAnnotation").execute().returnResponse();
+        checkResponse(response, 200, ResourceMediaType.GREETINGS_JSON);
+    }
+
+    // client without @Produces and resource with @Produces(MediaType.APPLICATION_XML)
+    @Test
+    @RunAsClient
+    public void producesXml_withoutAnnotation() throws IOException {
+        HttpResponse response = Request.Get(HTTP_REST + "producesXml_withoutAnnotation").execute().returnResponse();
+        checkResponse(response, 500, EXPECTED_ERROR_406);
+    }
+
+    // client with @Produces() and resource with @Produces(MediaType.TEXT_PLAIN)
+    @Test
+    @RunAsClient
+    public void producesText_defaultAnnotationValue() throws IOException {
+        HttpResponse response = Request.Get(HTTP_REST + "producesText_defaultAnnotationValue").execute().returnResponse();
+        checkResponse(response, 200, ResourceMediaType.GREETINGS_TEXT);
+    }
+
+    // client with @Produces() and resource with @Produces(MediaType.APPLICATION_JSON)
+    @Test
+    @RunAsClient
+    public void producesJson_defaultAnnotationValue() throws IOException {
+        HttpResponse response = Request.Get(HTTP_REST + "producesJson_defaultAnnotationValue").execute().returnResponse();
+        checkResponse(response, 200, ResourceMediaType.GREETINGS_JSON);
+    }
+
+    // client with @Produces() and resource with @Produces(MediaType.APPLICATION_XML)
+    @Test
+    @RunAsClient
+    public void producesXml_defaultAnnotationValue() throws IOException {
+        HttpResponse response = Request.Get(HTTP_REST + "producesXml_defaultAnnotationValue").execute().returnResponse();
+        checkResponse(response, 200, ResourceMediaType.GREETINGS_XML);
+    }
+
+
+    // client with @Produces(MediaType.TEXT_PLAIN) and resource with @Produces(MediaType.TEXT_PLAIN)
+    @Test
+    @RunAsClient
+    public void producesText_annotationValueTextPlain() throws IOException {
+        HttpResponse response = Request.Get(HTTP_REST + "producesText_annotationValueTextPlain").execute().returnResponse();
+        checkResponse(response, 200, ResourceMediaType.GREETINGS_TEXT);
+    }
+
+    // client with @Produces(MediaType.TEXT_PLAIN) and resource with @Produces(MediaType.APPLICATION_JSON)
+    @Test
+    @RunAsClient
+    public void producesJson_annotationValueTextPlain() throws IOException {
+        HttpResponse response = Request.Get(HTTP_REST + "producesJson_annotationValueTextPlain").execute().returnResponse();
+        checkResponse(response, 500, EXPECTED_ERROR_406);
+    }
+
+    // @Consumes
+
+    // client without @Consumes and resource with @Consumes(MediaType.TEXT_PLAIN)
+    @Test
+    @RunAsClient
+    public void consumesText_withoutAnnotation() throws IOException {
+        HttpResponse response = Request.Get(HTTP_REST + "consumesText_withoutAnnotation").execute().returnResponse();
+        checkResponse(response, 500, EXPECTED_ERROR_415);
+    }
+
+    // client without @Consumes and resource with @Consumes(MediaType.APPLICATION_JSON)
+    @Test
+    @RunAsClient
+    public void consumesJson_withoutAnnotation() throws IOException {
+        HttpResponse response = Request.Get(HTTP_REST + "consumesJson_withoutAnnotation").execute().returnResponse();
+        checkResponse(response, 200, ResourceMediaType.GREETINGS_JSON);
+    }
+
+    // client with @Consumes() and resource with @Consumes(MediaType.TEXT_PLAIN)
+    @Test
+    @RunAsClient
+    public void consumesText_defaultAnnotationValue() throws IOException {
+        HttpResponse response = Request.Get(HTTP_REST + "consumesText_defaultAnnotationValue").execute().returnResponse();
+        checkResponse(response, 200, ResourceMediaType.GREETINGS_TEXT);
+    }
+
+    // client with @Consumes(MediaType.TEXT_PLAIN) and resource with @Consumes(MediaType.TEXT_PLAIN)
+    @Test
+    @RunAsClient
+    public void consumesText_annotationValueTextPlain() throws IOException {
+        HttpResponse response = Request.Get(HTTP_REST + "consumesText_annotationValueTextPlain").execute().returnResponse();
+        checkResponse(response, 200, ResourceMediaType.GREETINGS_TEXT);
+    }
+
+    private void checkResponse(HttpResponse response, int expectedStatusCode, String expectedContent) throws IOException {
+        assertThat(response.getStatusLine().getStatusCode()).isEqualTo(expectedStatusCode);
+
+        String actualContent = EntityUtils.toString(response.getEntity(), "UTF-8");
+        assertThat(actualContent).isEqualTo(expectedContent);
+    }
+}


### PR DESCRIPTION
There is new default MediaType for client. It influences/breaks combinations when client has no annotation and resource has different than JSON (former version had text..)