### PR TITLE
fixing tests for 2.5.0 DR3

### DIFF
--- a/javaee/ejb-mdb-activemq/src/test/java/org/wildfly/swarm/ts/javaee/ejb/mdb/activemq/EjbMdbActivemqTest.java
+++ b/javaee/ejb-mdb-activemq/src/test/java/org/wildfly/swarm/ts/javaee/ejb/mdb/activemq/EjbMdbActivemqTest.java
@@ -5,7 +5,6 @@ import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,22 +26,21 @@ public class EjbMdbActivemqTest {
 
     @Test
     @RunAsClient
-    @InSequence(1)
-    public void sendMessages() throws IOException {
+    public void sendAndReceiveMessages() throws IOException {
+        StringBuilder expected = new StringBuilder();
         for (int i = 0; i < 10; i++) {
-            HttpResponse response = Request.Post("http://localhost:8080/")
-                    .bodyString("msg " + i, ContentType.TEXT_PLAIN).execute().returnResponse();
-            assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
-        }
-    }
+            expected.append("msg ").append(i);
 
-    @Test
-    @RunAsClient
-    @InSequence(2)
-    public void receivewMessages() {
-        String expected = "msg 0|msg 1|msg 2|msg 3|msg 4|msg 5|msg 6|msg 7|msg 8|msg 9";
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-            assertThat(Request.Get("http://localhost:8080/").execute().returnContent().asString()).isEqualTo(expected);
-        });
+            HttpResponse sendResponse = Request.Post("http://localhost:8080/")
+                    .bodyString("msg " + i, ContentType.TEXT_PLAIN).execute().returnResponse();
+            assertThat(sendResponse.getStatusLine().getStatusCode()).isEqualTo(200);
+
+            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+                String receiveResponse = Request.Get("http://localhost:8080/").execute().returnContent().asString();
+                assertThat(receiveResponse).isEqualTo(expected.toString());
+            });
+
+            expected.append("|");
+        }
     }
 }

--- a/javaee/ejb-mdb-amqp/src/test/java/org/wildfly/swarm/ts/javaee/ejb/mdb/amqp/EjbMdbAmqpTest.java
+++ b/javaee/ejb-mdb-amqp/src/test/java/org/wildfly/swarm/ts/javaee/ejb/mdb/amqp/EjbMdbAmqpTest.java
@@ -5,7 +5,6 @@ import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,22 +26,21 @@ public class EjbMdbAmqpTest {
 
     @Test
     @RunAsClient
-    @InSequence(1)
-    public void sendMessages() throws IOException {
+    public void sendAndReceiveMessages() throws IOException {
+        StringBuilder expected = new StringBuilder();
         for (int i = 0; i < 10; i++) {
-            HttpResponse response = Request.Post("http://localhost:8080/")
-                    .bodyString("msg " + i, ContentType.TEXT_PLAIN).execute().returnResponse();
-            assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
-        }
-    }
+            expected.append("msg ").append(i);
 
-    @Test
-    @RunAsClient
-    @InSequence(2)
-    public void receivewMessages() {
-        String expected = "msg 0|msg 1|msg 2|msg 3|msg 4|msg 5|msg 6|msg 7|msg 8|msg 9";
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-            assertThat(Request.Get("http://localhost:8080/").execute().returnContent().asString()).isEqualTo(expected);
-        });
+            HttpResponse sendResponse = Request.Post("http://localhost:8080/")
+                    .bodyString("msg " + i, ContentType.TEXT_PLAIN).execute().returnResponse();
+            assertThat(sendResponse.getStatusLine().getStatusCode()).isEqualTo(200);
+
+            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+                String receiveResponse = Request.Get("http://localhost:8080/").execute().returnContent().asString();
+                assertThat(receiveResponse).isEqualTo(expected.toString());
+            });
+
+            expected.append("|");
+        }
     }
 }

--- a/microprofile/microprofile-config-1.2/src/main/java/org/wildfly/swarm/ts/microprofile/config/v12/HelloServlet.java
+++ b/microprofile/microprofile-config-1.2/src/main/java/org/wildfly/swarm/ts/microprofile/config/v12/HelloServlet.java
@@ -23,8 +23,12 @@ public class HelloServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        String[] arrayProperty = config.getValue("arrayProperty", String[].class);
-        resp.getWriter().println("arrayproperty programatic: " + Arrays.toString(arrayProperty));
-        resp.getWriter().println("arrayproperty injected list: " + String.join(",", arrayPropertyList));
+        boolean programmatic = Boolean.parseBoolean(req.getParameter("programmatic"));
+        if (programmatic) {
+            String[] arrayProperty = config.getValue("arrayProperty", String[].class);
+            resp.getWriter().println("programmatic: " + Arrays.toString(arrayProperty));
+        } else {
+            resp.getWriter().println("injected: " + String.join(",", arrayPropertyList));
+        }
     }
 }

--- a/microprofile/microprofile-config-1.2/src/main/resources/project-defaults.yml
+++ b/microprofile/microprofile-config-1.2/src/main/resources/project-defaults.yml
@@ -1,4 +1,4 @@
-swarm:
+thorntail:
   microprofile:
     config:
       config-sources:

--- a/microprofile/microprofile-config-1.2/src/test/java/org/wildfly/swarm/ts/microprofile/config/v12/MicroProfileConfig12Test.java
+++ b/microprofile/microprofile-config-1.2/src/test/java/org/wildfly/swarm/ts/microprofile/config/v12/MicroProfileConfig12Test.java
@@ -16,10 +16,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MicroProfileConfig12Test {
     @Test
     @RunAsClient
-    public void test() throws IOException {
-        String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-        assertThat(response).isEqualTo(
-                "arrayproperty programatic: [element1, element2, element3, element41\\,element42]\n" +
-                "arrayproperty injected list: element1,element2,element3,element41\\,element42\n");
+    public void programmatic() throws IOException {
+        String response = Request.Get("http://localhost:8080?programmatic=true").execute().returnContent().asString();
+        assertThat(response).isEqualTo("programmatic: [element1, element2, element3, element41\\,element42]\n");
+    }
+
+    @Test
+    @RunAsClient
+    public void injected() throws IOException {
+        String response = Request.Get("http://localhost:8080?programmatic=false").execute().returnContent().asString();
+        assertThat(response).isEqualTo("injected: element1,element2,element3,element41\\,element42\n");
     }
 }

--- a/microprofile/microprofile-config-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/config/v13/EmptyPropertiesServlet.java
+++ b/microprofile/microprofile-config-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/config/v13/EmptyPropertiesServlet.java
@@ -1,0 +1,31 @@
+package org.wildfly.swarm.ts.microprofile.config.v13;
+
+import org.eclipse.microprofile.config.Config;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet("/empty-properties")
+public class EmptyPropertiesServlet extends HttpServlet {
+    private static final String EMPTY_PROPERTY = "my.empty.system.property";
+
+    private static final String PROP_FILE_EMPTY_PROPERTY = "my.empty.property.in.config.file";
+
+    @Inject
+    private Config config;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        System.setProperty(EMPTY_PROPERTY, "");
+
+        String fromSystemProperty = config.getValue(EMPTY_PROPERTY, String.class);
+        resp.getWriter().println("Empty system property: '" + fromSystemProperty + "'");
+
+        String fromConfigFile = config.getValue(PROP_FILE_EMPTY_PROPERTY, String.class);
+        resp.getWriter().println("Empty property in config file: '" + fromConfigFile + "'");
+    }
+}

--- a/microprofile/microprofile-config-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/config/v13/HelloServlet.java
+++ b/microprofile/microprofile-config-1.3/src/main/java/org/wildfly/swarm/ts/microprofile/config/v13/HelloServlet.java
@@ -1,19 +1,18 @@
 package org.wildfly.swarm.ts.microprofile.config.v13;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import javax.inject.Inject;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 @WebServlet("/")
 public class HelloServlet extends HttpServlet {
@@ -101,9 +100,9 @@ public class HelloServlet extends HttpServlet {
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         // Check mapping rule: from config property name to environment variable
         // https://github.com/eclipse/microprofile-config/issues/264
-        final String key = "MY_ENVIRONMENT_VARIABLE";
-        final String keyDots = "MY.ENVIRONMENT.VARIABLE";
-        final String keyDotsLowercase = "my.environment.variable";
+        String key = "MY_ENVIRONMENT_VARIABLE";
+        String keyDots = "MY.ENVIRONMENT.VARIABLE";
+        String keyDotsLowercase = "my.environment.variable";
         resp.getWriter().println(key + ": " + config.getValue(key, String.class));
         resp.getWriter().println(keyDots + ": " + config.getValue(keyDots, String.class));
         resp.getWriter().println(keyDotsLowercase + ": " + config.getValue(keyDotsLowercase, String.class));
@@ -134,17 +133,16 @@ public class HelloServlet extends HttpServlet {
 
         // custom converter on custom class
         resp.getWriter().println("my.stringWrapper.property: " + stringWrapper.getProperty());
-        resp.getWriter().println("my.stringWrapper.property: " +
-                                         config.getValue("my.stringWrapper.property",
-                                                         StringWrapper.class).getProperty());
+        resp.getWriter().println("my.stringWrapper.property: "
+                + config.getValue("my.stringWrapper.property", StringWrapper.class).getProperty());
 
         String[] animals = config.getValue("my.animals.array.property", String[].class);
-        resp.getWriter().println("my.animals.array.property.array: " +
-                                         (animals.length == 2 ? animals[0] + ", " + animals[1]
-                                                 : "unexpected length: " + animals.length));
-        resp.getWriter().println("my.animals.array.property.array: " +
-                                         (myAnimalsArray.length == 2 ? myAnimalsArray[0] + ", " + myAnimalsArray[1]
-                                                 : "unexpected length: " + myAnimalsArray.length));
+        resp.getWriter().println("my.animals.array.property.array: " + (animals.length == 2
+                ? animals[0] + ", " + animals[1]
+                : "unexpected length: " + animals.length));
+        resp.getWriter().println("my.animals.array.property.array: " + (myAnimalsArray.length == 2
+                ? myAnimalsArray[0] + ", " + myAnimalsArray[1]
+                : "unexpected length: " + myAnimalsArray.length));
         resp.getWriter().println("my.animals.array.property.list: " + myAnimalsList);
         // Note: HashSet will sort set (Zebra, Alligator => Alligator, Zebra)
         resp.getWriter().println("myAnimalsSet.class: " + myAnimalsSet.getClass().toString());

--- a/microprofile/microprofile-config-1.3/src/main/resources/META-INF/microprofile-config.properties
+++ b/microprofile/microprofile-config-1.3/src/main/resources/META-INF/microprofile-config.properties
@@ -2,3 +2,4 @@ app.timeout=314159
 fileProperty=This will be overriden by a file
 yamlOrdereredProperty=Property from default config source
 tck.config.test.javaconfig.converter.urlvalue=http://microprofile.io
+my.empty.property.in.config.file=

--- a/microprofile/microprofile-config-1.3/src/test/java/org/wildfly/swarm/ts/microprofile/config/v13/MicroProfileConfig13Test.java
+++ b/microprofile/microprofile-config-1.3/src/test/java/org/wildfly/swarm/ts/microprofile/config/v13/MicroProfileConfig13Test.java
@@ -18,34 +18,40 @@ public class MicroProfileConfig13Test {
     @RunAsClient
     public void test() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-
-        assertThat(response).isEqualTo(
-                "MY_ENVIRONMENT_VARIABLE: value from surefire envvar\n" +
-                        "MY.ENVIRONMENT.VARIABLE: value from surefire envvar\n" +
-                        "my.environment.variable: value from surefire envvar\n" +
-                        "MY_ENVIRONMENT_VARIABLE: value from surefire envvar\n" +
-                        "MY.ENVIRONMENT.VARIABLE: value from surefire envvar\n" +
-                        "my.environment.variable: value from surefire envvar\n" +
-                        "URI: http://microprofile.io\n" +
-                        "Optional notExisting: false\n" +
-                        "Optional existing: true\n" +
-                        "my.boolean.property: true\n" +
-                        "my.boolean.property: true\n" +
-                        "my.int.property: 42\n" +
-                        "my.int.property: 42\n" +
-                        "my.long.property: 9223372036854775807\n" +
-                        "my.long.property: 9223372036854775807\n" +
-                        "my.float.property: 3.14\n" +
-                        "my.float.property: 3.14\n" +
-                        "my.double.property: 10.0\n" +
-                        "my.double.property: 10.0\n" +
-                        "my.stringWrapper.property: Converted stringWrapperContent\n" +
-                        "my.stringWrapper.property: Converted stringWrapperContent\n" +
-                        "my.animals.array.property.array: Zebra, Alligator\n" +
-                        "my.animals.array.property.array: Zebra, Alligator\n" +
-                        "my.animals.array.property.list: [Zebra, Alligator]\n" +
-                        "myAnimalsSet.class: class java.util.HashSet\n" +
-                        "my.animals.array.property.set: [Alligator, Zebra]\n"
+        assertThat(response).isEqualTo(""
+                + "MY_ENVIRONMENT_VARIABLE: value from surefire envvar\n"
+                + "MY.ENVIRONMENT.VARIABLE: value from surefire envvar\n"
+                + "my.environment.variable: value from surefire envvar\n"
+                + "MY_ENVIRONMENT_VARIABLE: value from surefire envvar\n"
+                + "MY.ENVIRONMENT.VARIABLE: value from surefire envvar\n"
+                + "my.environment.variable: value from surefire envvar\n"
+                + "URI: http://microprofile.io\n"
+                + "Optional notExisting: false\n"
+                + "Optional existing: true\n"
+                + "my.boolean.property: true\n"
+                + "my.boolean.property: true\n"
+                + "my.int.property: 42\n"
+                + "my.int.property: 42\n"
+                + "my.long.property: 9223372036854775807\n"
+                + "my.long.property: 9223372036854775807\n"
+                + "my.float.property: 3.14\n"
+                + "my.float.property: 3.14\n"
+                + "my.double.property: 10.0\n"
+                + "my.double.property: 10.0\n"
+                + "my.stringWrapper.property: Converted stringWrapperContent\n"
+                + "my.stringWrapper.property: Converted stringWrapperContent\n"
+                + "my.animals.array.property.array: Zebra, Alligator\n"
+                + "my.animals.array.property.array: Zebra, Alligator\n"
+                + "my.animals.array.property.list: [Zebra, Alligator]\n"
+                + "myAnimalsSet.class: class java.util.HashSet\n"
+                + "my.animals.array.property.set: [Alligator, Zebra]\n"
         );
+    }
+
+    @Test
+    @RunAsClient
+    public void testEmptyProperty() throws IOException {
+        String response = Request.Get("http://localhost:8080/empty-properties").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Empty system property: ''\nEmpty property in config file: ''\n");
     }
 }

--- a/protocols/https-2way-elytron/src/test/java/org/wildfly/swarm/ts/protocols/https/twoway/elytron/Https2wayElytronTest.java
+++ b/protocols/https-2way-elytron/src/test/java/org/wildfly/swarm/ts/protocols/https/twoway/elytron/Https2wayElytronTest.java
@@ -3,8 +3,6 @@ package org.wildfly.swarm.ts.protocols.https.twoway.elytron;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.TrustAllStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
@@ -15,7 +13,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLException;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -67,7 +65,7 @@ public class Https2wayElytronTest {
 
             assertThatThrownBy(() -> {
                 Executor.newInstance(httpClient).execute(Request.Get("https://localhost:8443/"));
-            }).isExactlyInstanceOf(SSLHandshakeException.class);
+            }).isInstanceOf(SSLException.class);
         }
     }
 
@@ -86,7 +84,7 @@ public class Https2wayElytronTest {
 
             assertThatThrownBy(() -> {
                 Executor.newInstance(httpClient).execute(Request.Get("https://localhost:8443/"));
-            }).isExactlyInstanceOf(SSLHandshakeException.class);
+            }).isInstanceOf(SSLException.class);
         }
     }
 
@@ -104,7 +102,7 @@ public class Https2wayElytronTest {
 
             assertThatThrownBy(() -> {
                 Executor.newInstance(httpClient).execute(Request.Get("https://localhost:8443/"));
-            }).isExactlyInstanceOf(SSLHandshakeException.class);
+            }).isInstanceOf(SSLException.class);
         }
     }
 }

--- a/protocols/https-2way/src/test/java/org/wildfly/swarm/ts/protocols/https/twoway/Https2wayTest.java
+++ b/protocols/https-2way/src/test/java/org/wildfly/swarm/ts/protocols/https/twoway/Https2wayTest.java
@@ -3,8 +3,6 @@ package org.wildfly.swarm.ts.protocols.https.twoway;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.TrustAllStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
@@ -15,7 +13,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLException;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -67,7 +65,7 @@ public class Https2wayTest {
 
             assertThatThrownBy(() -> {
                 Executor.newInstance(httpClient).execute(Request.Get("https://localhost:8443/"));
-            }).isExactlyInstanceOf(SSLHandshakeException.class);
+            }).isInstanceOf(SSLException.class);
         }
     }
 
@@ -86,7 +84,7 @@ public class Https2wayTest {
 
             assertThatThrownBy(() -> {
                 Executor.newInstance(httpClient).execute(Request.Get("https://localhost:8443/"));
-            }).isExactlyInstanceOf(SSLHandshakeException.class);
+            }).isInstanceOf(SSLException.class);
         }
     }
 
@@ -104,7 +102,7 @@ public class Https2wayTest {
 
             assertThatThrownBy(() -> {
                 Executor.newInstance(httpClient).execute(Request.Get("https://localhost:8443/"));
-            }).isExactlyInstanceOf(SSLHandshakeException.class);
+            }).isInstanceOf(SSLException.class);
         }
     }
 }


### PR DESCRIPTION
fixes:
- EjbMdb* tests where order was flaky
- MicroProfileConfig12Test was separated to recognize that it is programatic that causes fail
- https_clientCertificateUnknownToServer sometimes creates SSLException.class(readHandshakeRecord) and sometimes SSLHandshakeException.class both poiting to the same handshake problem 
-----
There still remains 2 issues after this PR:
  org.wildfly.swarm.ts.microprofile.config.v12.MicroProfileConfig12Test.programatic
  org.wildfly.swarm.ts.microprofile.config.v13.MicroProfileConfig13Test.testEmptyProperty