### PR TITLE
[ENTSWM-714] explicit SUPPORTED_PROTOCOLS for Elytron

### DIFF
--- a/protocols/https-2way-authz-elytron/src/test/java/org/wildfly/swarm/ts/protocols/https/twoway/authz/elytron/Https2wayAuthzElytronTest.java
+++ b/protocols/https-2way-authz-elytron/src/test/java/org/wildfly/swarm/ts/protocols/https/twoway/authz/elytron/Https2wayAuthzElytronTest.java
@@ -4,12 +4,12 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
@@ -26,6 +26,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @RunWith(Arquillian.class)
 @DefaultDeployment
 public class Https2wayAuthzElytronTest {
+    private static final String[] SUPPORTED_PROTOCOLS = {"TLSv1.2"};
+
     @Test
     @RunAsClient
     public void http() throws IOException {
@@ -41,9 +43,10 @@ public class Https2wayAuthzElytronTest {
                 .loadKeyMaterial(new File("target/client-keystore.jks"), clientPassword, clientPassword)
                 .loadTrustMaterial(new File("target/client-truststore.jks"), clientPassword)
                 .build();
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
+                SUPPORTED_PROTOCOLS, null, new DefaultHostnameVerifier());
         try (CloseableHttpClient httpClient = HttpClients.custom()
-                .setSSLContext(sslContext)
-                .setSSLHostnameVerifier(new DefaultHostnameVerifier())
+                .setSSLSocketFactory(sslSocketFactory)
                 .build()) {
 
             Executor executor = Executor.newInstance(httpClient);
@@ -68,9 +71,10 @@ public class Https2wayAuthzElytronTest {
                 .loadKeyMaterial(new File("target/guest-client-keystore.jks"), clientPassword, clientPassword)
                 .loadTrustMaterial(new File("target/client-truststore.jks"), clientPassword)
                 .build();
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
+                SUPPORTED_PROTOCOLS, null, new DefaultHostnameVerifier());
         try (CloseableHttpClient httpClient = HttpClients.custom()
-                .setSSLContext(sslContext)
-                .setSSLHostnameVerifier(new DefaultHostnameVerifier())
+                .setSSLSocketFactory(sslSocketFactory)
                 .build()) {
 
             Executor executor = Executor.newInstance(httpClient);
@@ -94,9 +98,10 @@ public class Https2wayAuthzElytronTest {
         SSLContext sslContext = SSLContexts.custom()
                 .loadKeyMaterial(new File("target/client-keystore.jks"), clientPassword, clientPassword)
                 .build();
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
+                SUPPORTED_PROTOCOLS, null, new DefaultHostnameVerifier());
         try (CloseableHttpClient httpClient = HttpClients.custom()
-                .setSSLContext(sslContext)
-                .setSSLHostnameVerifier(new DefaultHostnameVerifier())
+                .setSSLSocketFactory(sslSocketFactory)
                 .build()) {
 
             assertThatThrownBy(() -> {
@@ -113,9 +118,10 @@ public class Https2wayAuthzElytronTest {
                 .loadKeyMaterial(new File("target/unknown-client-keystore.jks"), clientPassword, clientPassword)
                 .loadTrustMaterial(new File("target/client-truststore.jks"), clientPassword)
                 .build();
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
+                SUPPORTED_PROTOCOLS, null, new DefaultHostnameVerifier());
         try (CloseableHttpClient httpClient = HttpClients.custom()
-                .setSSLContext(sslContext)
-                .setSSLHostnameVerifier(new DefaultHostnameVerifier())
+                .setSSLSocketFactory(sslSocketFactory)
                 .build()) {
 
             Executor executor = Executor.newInstance(httpClient);
@@ -139,9 +145,10 @@ public class Https2wayAuthzElytronTest {
         SSLContext sslContext = SSLContexts.custom()
                 .loadKeyMaterial(new File("target/unknown-client-keystore.jks"), clientPassword, clientPassword)
                 .build();
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
+                SUPPORTED_PROTOCOLS, null, new DefaultHostnameVerifier());
         try (CloseableHttpClient httpClient = HttpClients.custom()
-                .setSSLContext(sslContext)
-                .setSSLHostnameVerifier(new DefaultHostnameVerifier())
+                .setSSLSocketFactory(sslSocketFactory)
                 .build()) {
 
             assertThatThrownBy(() -> {

--- a/protocols/https-2way-elytron/src/test/java/org/wildfly/swarm/ts/protocols/https/twoway/elytron/Https2wayElytronTest.java
+++ b/protocols/https-2way-elytron/src/test/java/org/wildfly/swarm/ts/protocols/https/twoway/elytron/Https2wayElytronTest.java
@@ -3,6 +3,7 @@ package org.wildfly.swarm.ts.protocols.https.twoway.elytron;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
@@ -24,6 +25,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @RunWith(Arquillian.class)
 @DefaultDeployment
 public class Https2wayElytronTest {
+    private static final String[] SUPPORTED_PROTOCOLS = {"TLSv1.2"};
+
     @Test
     @RunAsClient
     public void http() throws IOException {
@@ -39,9 +42,10 @@ public class Https2wayElytronTest {
                 .loadKeyMaterial(new File("target/client-keystore.jks"), clientPassword, clientPassword)
                 .loadTrustMaterial(new File("target/client-truststore.jks"), clientPassword)
                 .build();
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
+                SUPPORTED_PROTOCOLS, null, new DefaultHostnameVerifier());
         try (CloseableHttpClient httpClient = HttpClients.custom()
-                .setSSLContext(sslContext)
-                .setSSLHostnameVerifier(new DefaultHostnameVerifier())
+                .setSSLSocketFactory(sslSocketFactory)
                 .build()) {
 
             String response = Executor.newInstance(httpClient)
@@ -58,9 +62,10 @@ public class Https2wayElytronTest {
         SSLContext sslContext = SSLContexts.custom()
                 .loadKeyMaterial(new File("target/client-keystore.jks"), clientPassword, clientPassword)
                 .build();
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
+                SUPPORTED_PROTOCOLS, null, new DefaultHostnameVerifier());
         try (CloseableHttpClient httpClient = HttpClients.custom()
-                .setSSLContext(sslContext)
-                .setSSLHostnameVerifier(new DefaultHostnameVerifier())
+                .setSSLSocketFactory(sslSocketFactory)
                 .build()) {
 
             assertThatThrownBy(() -> {
@@ -77,9 +82,10 @@ public class Https2wayElytronTest {
                 .loadKeyMaterial(new File("target/unknown-client-keystore.jks"), clientPassword, clientPassword)
                 .loadTrustMaterial(new File("target/client-truststore.jks"), clientPassword)
                 .build();
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
+                SUPPORTED_PROTOCOLS, null, new DefaultHostnameVerifier());
         try (CloseableHttpClient httpClient = HttpClients.custom()
-                .setSSLContext(sslContext)
-                .setSSLHostnameVerifier(new DefaultHostnameVerifier())
+                .setSSLSocketFactory(sslSocketFactory)
                 .build()) {
 
             assertThatThrownBy(() -> {
@@ -95,9 +101,10 @@ public class Https2wayElytronTest {
         SSLContext sslContext = SSLContexts.custom()
                 .loadKeyMaterial(new File("target/unknown-client-keystore.jks"), clientPassword, clientPassword)
                 .build();
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
+                SUPPORTED_PROTOCOLS, null, new DefaultHostnameVerifier());
         try (CloseableHttpClient httpClient = HttpClients.custom()
-                .setSSLContext(sslContext)
-                .setSSLHostnameVerifier(new DefaultHostnameVerifier())
+                .setSSLSocketFactory(sslSocketFactory)
                 .build()) {
 
             assertThatThrownBy(() -> {


### PR DESCRIPTION
In src/main/resources/project-defaults.yml there are protocols specified:
```
     server-ssl-contexts:
      my-server-ssl-context:
        key-manager: my-key-manager
        protocols:
        - TLSv1.2
```
For IBM JDK httpClient needs to have supported protocols specified.
This can be achieved by flag useSystemProperties:
```
httpClient = HttpClients.custom().useSystemProperties()  
```
and run it with: 
```
-Dhttps.protocols=TLSv1.2
```
OR specify explicitly supported protocols:
```
String[] SUPPORTED_PROTOCOLS = {"TLSv1", "TLSv1.1", "TLSv1.2"}
httpClient = HttpClients.custom()
                .setSSLSocketFactory(new SSLConnectionSocketFactory(sslContext, SUPPORTED_PROTOCOLS, null, new DefaultHostnameVerifier())
```
Without this explicit specification there appears TLSv1 successul handshake (sofar only successful TLSv1.2 connections were there) and following TLSv1.2 failing handshake:
```
*** ClientHello, TLSv1
...
main, WRITE: TLSv1 Handshake, length = 102
main, READ: TLSv1.2 Alert, length = 2
main, RECV TLSv1.2 ALERT:  fatal, handshake_failure
main, called closeSocket()
```