### PR TITLE
replaced deprecated new JsonParser().parse()

### DIFF
--- a/hollow-jar/microprofile/src/test/java/org/wildfly/swarm/ts/hollow/jar/microprofile/MicroProfileHollowJarIT.java
+++ b/hollow-jar/microprofile/src/test/java/org/wildfly/swarm/ts/hollow/jar/microprofile/MicroProfileHollowJarIT.java
@@ -49,7 +49,7 @@ public class MicroProfileHollowJarIT {
     @Test
     public void jaxrsCdiJsonp() throws IOException {
         String response = Request.Get("http://localhost:8080/basic").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().size()).isEqualTo(1);
         assertThat(json.getAsJsonObject().has("content")).isTrue();
@@ -182,7 +182,7 @@ public class MicroProfileHollowJarIT {
     @Test
     public void healthCheck() throws IOException {
         String response = Request.Get("http://localhost:8080/health").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().has("status")).isTrue();
         assertThat(json.getAsJsonObject().get("status").getAsString()).isEqualTo("UP");
@@ -214,7 +214,7 @@ public class MicroProfileHollowJarIT {
     public void metrics_2_jsonMetadata() throws IOException {
         String response = Request.Options("http://localhost:8080/metrics")
                 .addHeader("Accept", "application/json").execute().returnContent().asString();
-        JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
         assertThat(json.has("application")).isTrue();
         JsonObject app = json.getAsJsonObject("application");
         assertThat(app.has("hello-count")).isTrue();
@@ -226,7 +226,7 @@ public class MicroProfileHollowJarIT {
     public void metrics_3_jsonData() throws IOException {
         String response = Request.Get("http://localhost:8080/metrics")
                 .addHeader("Accept", "application/json").execute().returnContent().asString();
-        JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
         assertThat(json.has("application")).isTrue();
         JsonObject app = json.getAsJsonObject("application");
         assertThat(app.has("hello-count")).isTrue();

--- a/javaee/jaxrs-cdi-jpa-jta/src/test/java/org/wildfly/swarm/ts/javaee/jaxrs/cdi/jpa/jta/JaxrsCdiJpaJtaTest.java
+++ b/javaee/jaxrs-cdi-jpa-jta/src/test/java/org/wildfly/swarm/ts/javaee/jaxrs/cdi/jpa/jta/JaxrsCdiJpaJtaTest.java
@@ -29,7 +29,7 @@ public class JaxrsCdiJpaJtaTest {
     @RunAsClient
     public void empty() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-        JsonArray json = new JsonParser().parse(response).getAsJsonArray();
+        JsonArray json = JsonParser.parseString(response).getAsJsonArray();
         assertThat(json.size()).isEqualTo(0);
     }
 
@@ -51,7 +51,7 @@ public class JaxrsCdiJpaJtaTest {
     @RunAsClient
     public void notEmpty() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-        JsonArray json = new JsonParser().parse(response).getAsJsonArray();
+        JsonArray json = JsonParser.parseString(response).getAsJsonArray();
         assertThat(json.size()).isEqualTo(1);
     }
 
@@ -60,7 +60,7 @@ public class JaxrsCdiJpaJtaTest {
     @RunAsClient
     public void content() throws IOException {
         String response = Request.Get(url).execute().returnContent().asString();
-        JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
         assertThat(json.get("title").getAsString()).isEqualTo("Title");
         assertThat(json.get("author").getAsString()).isEqualTo("Author");
     }
@@ -78,7 +78,7 @@ public class JaxrsCdiJpaJtaTest {
     @RunAsClient
     public void emptyAgain() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-        JsonArray json = new JsonParser().parse(response).getAsJsonArray();
+        JsonArray json = JsonParser.parseString(response).getAsJsonArray();
         assertThat(json.size()).isEqualTo(0);
     }
 }

--- a/javaee/jaxrs-client-json/src/test/java/org/wildfly/swarm/ts/javaee/jaxrs/client/json/JaxrsClientJsonTest.java
+++ b/javaee/jaxrs-client-json/src/test/java/org/wildfly/swarm/ts/javaee/jaxrs/client/json/JaxrsClientJsonTest.java
@@ -24,7 +24,7 @@ public class JaxrsClientJsonTest {
         HttpResponse response = Request.Get("http://localhost:8080/client").execute().returnResponse();
         assertThat(response.getFirstHeader("Content-Type").getValue()).contains("application/json");
 
-        JsonElement json = new JsonParser().parse(EntityUtils.toString(response.getEntity()));
+        JsonElement json = JsonParser.parseString(EntityUtils.toString(response.getEntity()));
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().has("value")).isTrue();
         assertThat(json.getAsJsonObject().get("value").getAsString()).isEqualTo("JAX-RS Client got: Hello in JSON");

--- a/javaee/jaxrs-jsonb/src/test/java/org/wildfly/swarm/ts/javaee/jaxrs/jsonb/JaxrsJsonbAdapterTest.java
+++ b/javaee/jaxrs-jsonb/src/test/java/org/wildfly/swarm/ts/javaee/jaxrs/jsonb/JaxrsJsonbAdapterTest.java
@@ -20,7 +20,7 @@ public class JaxrsJsonbAdapterTest {
     @RunAsClient
     public void testToJson() throws IOException {
         String response = Request.Get("http://localhost:8080/adapt/to-json").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().size()).isEqualTo(1);
         assertThat(json.getAsJsonObject().has("hello")).isTrue();

--- a/javaee/jaxrs-jsonb/src/test/java/org/wildfly/swarm/ts/javaee/jaxrs/jsonb/JaxrsJsonbTest.java
+++ b/javaee/jaxrs-jsonb/src/test/java/org/wildfly/swarm/ts/javaee/jaxrs/jsonb/JaxrsJsonbTest.java
@@ -21,7 +21,7 @@ public class JaxrsJsonbTest {
     public void test() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
 
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().size()).isEqualTo(1);
         assertThat(json.getAsJsonObject().has("hello")).isTrue();

--- a/javaee/jaxrs-jsonp/src/test/java/org/wildfly/swarm/ts/javaee/jaxrs/jsonp/JaxrsJsonpTest.java
+++ b/javaee/jaxrs-jsonp/src/test/java/org/wildfly/swarm/ts/javaee/jaxrs/jsonp/JaxrsJsonpTest.java
@@ -21,7 +21,7 @@ public class JaxrsJsonpTest {
     public void test() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
 
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().size()).isEqualTo(1);
         assertThat(json.getAsJsonObject().has("hello")).isTrue();

--- a/javaee/jsonb/src/test/java/org/wildfly/swarm/ts/javaee/jsonb/JsonbAdapterTest.java
+++ b/javaee/jsonb/src/test/java/org/wildfly/swarm/ts/javaee/jsonb/JsonbAdapterTest.java
@@ -20,7 +20,7 @@ public class JsonbAdapterTest {
     @RunAsClient
     public void testToJson() throws IOException {
         String response = Request.Get("http://localhost:8080/adapt?case=to").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().size()).isEqualTo(1);
         assertThat(json.getAsJsonObject().has("hello")).isTrue();
@@ -31,7 +31,7 @@ public class JsonbAdapterTest {
     @RunAsClient
     public void testFromJson() throws IOException {
         String response = Request.Get("http://localhost:8080/adapt?case=from").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isFalse();
         assertThat(response).isEqualTo("world");
     }

--- a/javaee/jsonb/src/test/java/org/wildfly/swarm/ts/javaee/jsonb/JsonbTest.java
+++ b/javaee/jsonb/src/test/java/org/wildfly/swarm/ts/javaee/jsonb/JsonbTest.java
@@ -20,7 +20,7 @@ public class JsonbTest {
     @RunAsClient
     public void test() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().size()).isEqualTo(1);
         assertThat(json.getAsJsonObject().has("hello")).isTrue();

--- a/javaee/jsonp/src/test/java/org/wildfly/swarm/ts/javaee/jsonp/JsonpTest.java
+++ b/javaee/jsonp/src/test/java/org/wildfly/swarm/ts/javaee/jsonp/JsonpTest.java
@@ -20,7 +20,7 @@ public class JsonpTest {
     @RunAsClient
     public void test() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().size()).isEqualTo(1);
         assertThat(json.getAsJsonObject().has("hello")).isTrue();

--- a/microprofile/microprofile-1.0/src/test/java/org/wildfly/swarm/ts/microprofile/v10/MicroProfile10Test.java
+++ b/microprofile/microprofile-1.0/src/test/java/org/wildfly/swarm/ts/microprofile/v10/MicroProfile10Test.java
@@ -20,7 +20,7 @@ public class MicroProfile10Test {
     @RunAsClient
     public void test() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().size()).isEqualTo(1);
         assertThat(json.getAsJsonObject().has("content")).isTrue();

--- a/microprofile/microprofile-health-check-2.0/src/test/java/org/wildfly/swarm/ts/microprofile/health/check/v20/MicroProfileHealthCheck20Test.java
+++ b/microprofile/microprofile-health-check-2.0/src/test/java/org/wildfly/swarm/ts/microprofile/health/check/v20/MicroProfileHealthCheck20Test.java
@@ -47,7 +47,7 @@ public class MicroProfileHealthCheck20Test {
     }
 
     private void checkResponse(String response, int checkCount, String... names) {
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().has("status")).isTrue();
         assertThat(json.getAsJsonObject().get("status").getAsString()).isEqualTo("UP");

--- a/microprofile/microprofile-metrics-2.0/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v20/MicroProfileMetrics20Test.java
+++ b/microprofile/microprofile-metrics-2.0/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v20/MicroProfileMetrics20Test.java
@@ -26,7 +26,7 @@ public class MicroProfileMetrics20Test {
     public void applicationMetricsAreRegisteredAtDeploymentTime() throws IOException {
         String response = Request.Options("http://localhost:8080/metrics")
                 .addHeader("Accept", "application/json").execute().returnContent().asString();
-        JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
         assertThat(json.has("application")).isTrue();
         JsonObject app = json.getAsJsonObject("application");
         assertThat(app.size()).isEqualTo(4);
@@ -57,7 +57,7 @@ public class MicroProfileMetrics20Test {
     public void jsonMetadata() throws IOException {
         String response = Request.Options("http://localhost:8080/metrics")
                 .addHeader("Accept", "application/json").execute().returnContent().asString();
-        JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
         assertThat(json.has("application")).isTrue();
         JsonObject app = json.getAsJsonObject("application");
         assertThat(app.has("hello-count")).isTrue();
@@ -85,7 +85,7 @@ public class MicroProfileMetrics20Test {
     public void jsonData() throws IOException {
         String response = Request.Get("http://localhost:8080/metrics")
                 .addHeader("Accept", "application/json").execute().returnContent().asString();
-        JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
         assertThat(json.has("application")).isTrue();
         JsonObject app = json.getAsJsonObject("application");
         assertThat(app.has("hello-count")).isTrue();
@@ -135,7 +135,7 @@ public class MicroProfileMetrics20Test {
     public void vendorMetrics() throws IOException {
         String response = Request.Get("http://localhost:8080/metrics")
                 .addHeader("Accept", "application/json").execute().returnContent().asString();
-        JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
         assertThat(json.has("vendor")).isTrue();
         JsonObject vendor = json.getAsJsonObject("vendor");
         assertThat(vendor.has("loadedModules")).isTrue();
@@ -148,7 +148,7 @@ public class MicroProfileMetrics20Test {
     @InSequence(7)
     public void metricRegistryInjection() throws IOException {
         String response = Request.Get("http://localhost:8080/summary?of=all-registries").execute().returnContent().asString();
-        JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
 
         assertThat(json.has("base")).isTrue();
         JsonArray base = json.getAsJsonArray("base");
@@ -183,7 +183,7 @@ public class MicroProfileMetrics20Test {
     @InSequence(8)
     public void getAllRegisteredMetricsOfGivenType() throws IOException {
         String response = Request.Get("http://localhost:8080/summary?of=app-registry").execute().returnContent().asString();
-        JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
 
         assertThat(json.has("app-counters")).isTrue();
         JsonArray appCounters = json.getAsJsonArray("app-counters");

--- a/microprofile/microprofile-metrics-2.2/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v22/MicroProfileMetrics22Test.java
+++ b/microprofile/microprofile-metrics-2.2/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v22/MicroProfileMetrics22Test.java
@@ -39,7 +39,7 @@ public class MicroProfileMetrics22Test {
     public void jsonMetadata() throws IOException {
         String response = Request.Options("http://localhost:8080/metrics")
                 .addHeader("Accept", "application/json").execute().returnContent().asString();
-        JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
         assertThat(json.has("application")).isTrue();
         JsonObject app = json.getAsJsonObject("application");
         assertThat(app.has("hello-count")).isTrue();
@@ -55,7 +55,7 @@ public class MicroProfileMetrics22Test {
     public void jsonData() throws IOException {
         String response = Request.Get("http://localhost:8080/metrics")
                 .addHeader("Accept", "application/json").execute().returnContent().asString();
-        JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
         assertThat(json.has("application")).isTrue();
         JsonObject app = json.getAsJsonObject("application");
         assertThat(app.has("hello-count")).isTrue();
@@ -68,7 +68,7 @@ public class MicroProfileMetrics22Test {
     public void newMetrics() throws IOException {
         String response = Request.Get("http://localhost:8080/metrics")
                 .addHeader("Accept", "application/json").execute().returnContent().asString();
-        JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
         assertThat(json.has("base")).isTrue();
         JsonObject app = json.getAsJsonObject("base");
         assertThat(app.has("cpu.processCpuTime")).isTrue();

--- a/microprofile/microprofile-openapi-1.0/src/test/java/org/wildfly/swarm/ts/microprofile/openapi/v10/MicroProfileAnnotationsOpenApi10Test.java
+++ b/microprofile/microprofile-openapi-1.0/src/test/java/org/wildfly/swarm/ts/microprofile/openapi/v10/MicroProfileAnnotationsOpenApi10Test.java
@@ -39,7 +39,7 @@ public class MicroProfileAnnotationsOpenApi10Test {
     public void hitEndpoint() throws IOException {
         String response = Request.Get("http://localhost:8080/rest/user1").
                 addHeader("Accept", "application/json").execute().returnContent().asString();
-        JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
         assertThat(json.has("attribute1")).isTrue();
         assertThat(json.get("attribute1").getAsString()).isEqualTo("user1");
         assertThat(json.has("attribute2")).isTrue();

--- a/microprofile/microprofile-opentracing-1.0/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/v10/MicroProfileOpenTracing10Test.java
+++ b/microprofile/microprofile-opentracing-1.0/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/v10/MicroProfileOpenTracing10Test.java
@@ -43,7 +43,7 @@ public class MicroProfileOpenTracing10Test {
         // they are batched, so we need to wait a bit
         await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
             String response = Request.Get("http://localhost:16686/api/traces?service=test-traced-service").execute().returnContent().asString();
-            JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+            JsonObject json = JsonParser.parseString(response).getAsJsonObject();
             assertThat(json.has("data")).isTrue();
             JsonArray data = json.getAsJsonArray("data");
             assertThat(data.size()).isEqualTo(1);

--- a/microprofile/microprofile-opentracing-1.3/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/v13/MPOpenTracing13Test.java
+++ b/microprofile/microprofile-opentracing-1.3/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/v13/MPOpenTracing13Test.java
@@ -109,7 +109,7 @@ public class MPOpenTracing13Test {
         // they are batched, so we need to wait a bit
         await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
             String response = Request.Get("http://localhost:16686/api/traces?service=test-traced-service").execute().returnContent().asString();
-            JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+            JsonObject json = JsonParser.parseString(response).getAsJsonObject();
             assertThat(json.has("data")).isTrue();
             JsonArray data = json.getAsJsonArray("data");
 

--- a/microprofile/opentracing-fault-tolerance/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/fault/tolerance/MicroProfileOpenTracingFaultToleranceTest.java
+++ b/microprofile/opentracing-fault-tolerance/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/fault/tolerance/MicroProfileOpenTracingFaultToleranceTest.java
@@ -53,7 +53,7 @@ public class MicroProfileOpenTracingFaultToleranceTest {
         // they are batched, so we need to wait a bit
         await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
             String response = Request.Get("http://localhost:16686/api/traces?service=test-traced-service").execute().returnContent().asString();
-            JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+            JsonObject json = JsonParser.parseString(response).getAsJsonObject();
             assertThat(json.has("data")).isTrue();
             JsonArray data = json.getAsJsonArray("data");
             assertThat(data.size()).isEqualTo(suffixes.length);

--- a/microprofile/opentracing-restclient/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/restclient/MicroProfileOpenTracingRestClientTest.java
+++ b/microprofile/opentracing-restclient/src/test/java/org/wildfly/swarm/ts/microprofile/opentracing/restclient/MicroProfileOpenTracingRestClientTest.java
@@ -61,7 +61,7 @@ public class MicroProfileOpenTracingRestClientTest {
         // they are batched, so we need to wait a bit
         await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
             String response = Request.Get("http://localhost:16686/api/traces?service=test-traced-service").execute().returnContent().asString();
-            JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+            JsonObject json = JsonParser.parseString(response).getAsJsonObject();
             assertThat(json.has("data")).isTrue();
             JsonArray data = json.getAsJsonArray("data");
             assertThat(data.size()).isEqualTo(methods.length);

--- a/opentracing/basic/src/test/java/org/wildfly/swarm/ts/opentracing/basic/OpenTracingBasicTest.java
+++ b/opentracing/basic/src/test/java/org/wildfly/swarm/ts/opentracing/basic/OpenTracingBasicTest.java
@@ -43,7 +43,7 @@ public class OpenTracingBasicTest {
         // they are batched, so we need to wait a bit
         await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
             String response = Request.Get("http://localhost:16686/api/traces?service=test-traced-service").execute().returnContent().asString();
-            JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+            JsonObject json = JsonParser.parseString(response).getAsJsonObject();
             assertThat(json.has("data")).isTrue();
             JsonArray data = json.getAsJsonArray("data");
             assertThat(data.size()).isEqualTo(1);

--- a/opentracing/jaeger/src/test/java/org/wildfly/swarm/ts/opentracing/jaeger/OpenTracingJaegerTest.java
+++ b/opentracing/jaeger/src/test/java/org/wildfly/swarm/ts/opentracing/jaeger/OpenTracingJaegerTest.java
@@ -44,7 +44,7 @@ public class OpenTracingJaegerTest {
         // they are batched, so we need to wait a bit
         await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
             String response = Request.Get("http://localhost:16686/api/traces?service=test-traced-service").execute().returnContent().asString();
-            JsonObject json = new JsonParser().parse(response).getAsJsonObject();
+            JsonObject json = JsonParser.parseString(response).getAsJsonObject();
             assertThat(json.has("data")).isTrue();
             JsonArray data = json.getAsJsonArray("data");
             assertThat(data.size()).isEqualTo(1);

--- a/wildfly/management/src/test/java/org/wildfly/swarm/ts/wildfly/management/ManagementTest.java
+++ b/wildfly/management/src/test/java/org/wildfly/swarm/ts/wildfly/management/ManagementTest.java
@@ -27,7 +27,7 @@ public class ManagementTest {
     @RunAsClient
     public void management() throws IOException {
         String response = Request.Get("http://localhost:9990/management").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().has("core-service"));
         assertThat(json.getAsJsonObject().has("deployment"));

--- a/wildfly/monitor/src/test/java/org/wildfly/swarm/ts/wildfly/monitor/MonitorTest.java
+++ b/wildfly/monitor/src/test/java/org/wildfly/swarm/ts/wildfly/monitor/MonitorTest.java
@@ -28,7 +28,7 @@ public class MonitorTest {
     @RunAsClient
     public void myHealthCheck() throws IOException {
         String response = Request.Get("http://localhost:8080/my-health-check").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().get("id").getAsString()).isEqualTo("hello");
         assertThat(json.getAsJsonObject().get("result").getAsString()).isEqualTo("UP");
@@ -38,7 +38,7 @@ public class MonitorTest {
     @RunAsClient
     public void health() throws IOException {
         String response = Request.Get("http://localhost:8080/health").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().get("outcome").getAsString()).isEqualTo("UP");
         JsonArray checks = json.getAsJsonObject().getAsJsonArray("checks");
@@ -53,7 +53,7 @@ public class MonitorTest {
     @RunAsClient
     public void node() throws IOException {
         String response = Request.Get("http://localhost:8080/node").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().has("name")).isTrue();
         assertThat(json.getAsJsonObject().has("server-state")).isTrue();
@@ -66,7 +66,7 @@ public class MonitorTest {
     @RunAsClient
     public void heap() throws IOException {
         String response = Request.Get("http://localhost:8080/heap").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().has("heap-memory-usage")).isTrue();
         assertThat(json.getAsJsonObject().getAsJsonObject("heap-memory-usage").has("init")).isTrue();
@@ -84,7 +84,7 @@ public class MonitorTest {
     @RunAsClient
     public void threads() throws IOException {
         String response = Request.Get("http://localhost:8080/threads").execute().returnContent().asString();
-        JsonElement json = new JsonParser().parse(response);
+        JsonElement json = JsonParser.parseString(response);
         assertThat(json.isJsonObject()).isTrue();
         assertThat(json.getAsJsonObject().has("thread-count")).isTrue();
         assertThat(json.getAsJsonObject().has("peak-thread-count")).isTrue();


### PR DESCRIPTION
There are changes in JsonParser. This is simple full-text modification of deprecated approach.
new JsonParser().parse
->
JsonParser.parseString
All modified tests passed.