### PR TITLE
 [THORN-2561] metrics 2.3

### DIFF
--- a/microprofile/microprofile-metrics-2.3/pom.xml
+++ b/microprofile/microprofile-metrics-2.3/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.thorntail.ts</groupId>
+        <artifactId>ts-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>ts-microprofile-metrics-2.3</artifactId>
+    <packaging>war</packaging>
+
+    <name>Thorntail TS: MicroProfile Metrics 2.3</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>microprofile-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>jaxrs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>jsonp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>arquillian</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/microprofile/microprofile-metrics-2.3/pom.xml
+++ b/microprofile/microprofile-metrics-2.3/pom.xml
@@ -25,10 +25,6 @@
             <groupId>io.thorntail</groupId>
             <artifactId>jaxrs</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.thorntail</groupId>
-            <artifactId>jsonp</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/microprofile/microprofile-metrics-2.3/src/main/java/org/wildfly/swarm/ts/microprofile/metrics/v23/HelloResource.java
+++ b/microprofile/microprofile-metrics-2.3/src/main/java/org/wildfly/swarm/ts/microprofile/metrics/v23/HelloResource.java
@@ -1,0 +1,77 @@
+package org.wildfly.swarm.ts.microprofile.metrics.v23;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
+
+@Path("/")
+public class HelloResource {
+
+    @Inject
+    private MetricRegistry metrics;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        counter.inc();
+        return "Hello from programmatically counted method";
+    }
+
+    @PostConstruct
+    private void setupMetrics() {
+        counter = metrics.counter(Metadata.builder()
+          .withName("counter")
+          .withOptionalDisplayName(null)
+          .withOptionalDescription(null)
+          .withOptionalUnit(null)
+          .withOptionalType(MetricType.fromClassName("org.eclipse.microprofile.metrics.Counter"))
+          .build());
+        Tag[] tags = new Tag[] {
+                new Tag("tag1", "value1")
+        };
+        metrics.counter("tags-holder", tags);
+    }
+
+    private Counter counter;
+
+    @Metric(name = "tags-holder")
+    private Counter tagHolder;
+
+    @GET
+    @Path("timer")
+    @SimplyTimed(name = "simple-timer", absolute = true, unit = "milliseconds")
+    public String timed() throws InterruptedException {
+        Thread.sleep(10);
+        return "Hello from timed method";
+    }
+
+    @GET
+    @Path("optional-metadata")
+    public String optionalMetadata() {
+        counter.inc();
+        return "optional metadata";
+    }
+
+    @GET
+    @Path("tags-as-array")
+    public String getTagsAsArray() {
+        MetricID metricID = metrics.getCounters((mID, metric) -> mID.getName().equals("tags-holder")).firstKey();
+        return Arrays.stream(metricID.getTagsAsArray()).map(c -> c.getTagName() + ":" + c.getTagValue())
+                .collect(Collectors.joining(","));
+    }
+}

--- a/microprofile/microprofile-metrics-2.3/src/main/java/org/wildfly/swarm/ts/microprofile/metrics/v23/HelloResource.java
+++ b/microprofile/microprofile-metrics-2.3/src/main/java/org/wildfly/swarm/ts/microprofile/metrics/v23/HelloResource.java
@@ -25,13 +25,6 @@ public class HelloResource {
     @Inject
     private MetricRegistry metrics;
 
-    @GET
-    @Produces(MediaType.TEXT_PLAIN)
-    public String hello() {
-        counter.inc();
-        return "Hello from programmatically counted method";
-    }
-
     @PostConstruct
     private void setupMetrics() {
         counter = metrics.counter(Metadata.builder()

--- a/microprofile/microprofile-metrics-2.3/src/main/java/org/wildfly/swarm/ts/microprofile/metrics/v23/HelloResource.java
+++ b/microprofile/microprofile-metrics-2.3/src/main/java/org/wildfly/swarm/ts/microprofile/metrics/v23/HelloResource.java
@@ -7,8 +7,6 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Metadata;
@@ -25,6 +23,11 @@ public class HelloResource {
     @Inject
     private MetricRegistry metrics;
 
+    private Counter counter;
+
+    @Metric(name = "tags-holder")
+    private Counter tagHolder;
+
     @PostConstruct
     private void setupMetrics() {
         counter = metrics.counter(Metadata.builder()
@@ -40,15 +43,10 @@ public class HelloResource {
         metrics.counter("tags-holder", tags);
     }
 
-    private Counter counter;
-
-    @Metric(name = "tags-holder")
-    private Counter tagHolder;
-
     @GET
-    @Path("timer")
+    @Path("simple-timer")
     @SimplyTimed(name = "simple-timer", absolute = true, unit = "milliseconds")
-    public String timed() throws InterruptedException {
+    public String simplyTimed() throws InterruptedException {
         Thread.sleep(10);
         return "Hello from timed method";
     }
@@ -64,7 +62,8 @@ public class HelloResource {
     @Path("tags-as-array")
     public String getTagsAsArray() {
         MetricID metricID = metrics.getCounters((mID, metric) -> mID.getName().equals("tags-holder")).firstKey();
-        return Arrays.stream(metricID.getTagsAsArray()).map(c -> c.getTagName() + ":" + c.getTagValue())
+        return Arrays.stream(metricID.getTagsAsArray())
+                .map(c -> c.getTagName() + ":" + c.getTagValue())
                 .collect(Collectors.joining(","));
     }
 }

--- a/microprofile/microprofile-metrics-2.3/src/main/java/org/wildfly/swarm/ts/microprofile/metrics/v23/RestApplication.java
+++ b/microprofile/microprofile-metrics-2.3/src/main/java/org/wildfly/swarm/ts/microprofile/metrics/v23/RestApplication.java
@@ -1,0 +1,8 @@
+package org.wildfly.swarm.ts.microprofile.metrics.v23;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class RestApplication extends Application {
+}

--- a/microprofile/microprofile-metrics-2.3/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v23/MicroProfileOptionalMetadataTest.java
+++ b/microprofile/microprofile-metrics-2.3/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v23/MicroProfileOptionalMetadataTest.java
@@ -1,0 +1,42 @@
+package org.wildfly.swarm.ts.microprofile.metrics.v23;
+
+import java.io.IOException;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class MicroProfileOptionalMetadataTest {
+    @Test
+    @RunAsClient
+    @InSequence(1)
+    public void trigger() throws IOException {
+        String response = Request.Get("http://localhost:8080/optional-metadata").execute().returnContent().asString();
+        assertThat(response).isEqualTo("optional metadata");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(2)
+    public void jsonMetadata() throws IOException {
+        String response = Request.Options("http://localhost:8080/metrics")
+                .addHeader("Accept", "application/json").execute().returnContent().asString();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
+        assertThat(json.has("application")).isTrue();
+        JsonObject app = json.getAsJsonObject("application");
+        assertThat(app.has("counter")).isTrue();
+        JsonObject counter = app.getAsJsonObject("counter");
+        assertThat(counter.get("displayName").getAsString()).isEqualTo("counter");
+        assertThat(counter.has("description")).isFalse();
+    }
+}

--- a/microprofile/microprofile-metrics-2.3/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v23/MicroProfileOptionalMetadataTest.java
+++ b/microprofile/microprofile-metrics-2.3/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v23/MicroProfileOptionalMetadataTest.java
@@ -39,4 +39,17 @@ public class MicroProfileOptionalMetadataTest {
         assertThat(counter.get("displayName").getAsString()).isEqualTo("counter");
         assertThat(counter.has("description")).isFalse();
     }
+
+    @Test
+    @RunAsClient
+    @InSequence(3)
+    public void jsonData() throws IOException {
+        String response = Request.Get("http://localhost:8080/metrics")
+                .addHeader("Accept", "application/json").execute().returnContent().asString();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
+        assertThat(json.has("application")).isTrue();
+        JsonObject app = json.getAsJsonObject("application");
+        assertThat(app.has("counter")).isTrue();
+        assertThat(app.get("counter").getAsInt()).isEqualTo(1);
+    }
 }

--- a/microprofile/microprofile-metrics-2.3/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v23/MicroProfileSimpleTimerTest.java
+++ b/microprofile/microprofile-metrics-2.3/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v23/MicroProfileSimpleTimerTest.java
@@ -22,7 +22,7 @@ public class MicroProfileSimpleTimerTest {
     @RunAsClient
     @InSequence(1)
     public void trigger() throws IOException {
-        String response = Request.Get("http://localhost:8080/timer").execute().returnContent().asString();
+        String response = Request.Get("http://localhost:8080/simple-timer").execute().returnContent().asString();
         assertThat(response).isEqualTo("Hello from timed method");
     }
 

--- a/microprofile/microprofile-metrics-2.3/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v23/MicroProfileSimpleTimerTest.java
+++ b/microprofile/microprofile-metrics-2.3/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v23/MicroProfileSimpleTimerTest.java
@@ -1,0 +1,45 @@
+package org.wildfly.swarm.ts.microprofile.metrics.v23;
+
+import java.io.IOException;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class MicroProfileSimpleTimerTest {
+
+    @Test
+    @RunAsClient
+    @InSequence(1)
+    public void trigger() throws IOException {
+        String response = Request.Get("http://localhost:8080/timer").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello from timed method");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(2)
+    public void timerData() throws IOException {
+        String response = Request.Get("http://localhost:8080/metrics")
+                .addHeader("Accept", "application/json").execute().returnContent().asString();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
+        assertThat(json.has("application")).isTrue();
+        JsonObject app = json.getAsJsonObject("application");
+        assertThat(app.has("simple-timer")).isTrue();
+        JsonObject simpleTimer = app.getAsJsonObject("simple-timer");
+        assertThat(simpleTimer.has("count")).isTrue();
+        assertThat(simpleTimer.get("count").getAsInt()).isEqualTo(1);
+        assertThat(simpleTimer.has("elapsedTime")).isTrue();
+        assertThat(simpleTimer.get("elapsedTime").getAsDouble()).isGreaterThanOrEqualTo(10.0);
+    }
+}

--- a/microprofile/microprofile-metrics-2.3/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v23/MicroProfileTagsAsArrayTest.java
+++ b/microprofile/microprofile-metrics-2.3/src/test/java/org/wildfly/swarm/ts/microprofile/metrics/v23/MicroProfileTagsAsArrayTest.java
@@ -1,0 +1,24 @@
+package org.wildfly.swarm.ts.microprofile.metrics.v23;
+
+import java.io.IOException;
+
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class MicroProfileTagsAsArrayTest {
+
+    @Test
+    @RunAsClient
+    public void trigger() throws IOException {
+        String response = Request.Get("http://localhost:8080/tags-as-array").execute().returnContent().asString();
+        assertThat(response).isEqualTo("tag1:value1");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <module>microprofile/microprofile-jwt-1.1</module>
         <module>microprofile/microprofile-metrics-2.0</module>
         <module>microprofile/microprofile-metrics-2.2</module>
+        <module>microprofile/microprofile-metrics-2.3</module>
         <module>microprofile/microprofile-fault-tolerance-1.0</module>
         <module>microprofile/microprofile-fault-tolerance-2.0</module>
         <module>microprofile/microprofile-openapi-1.0</module>


### PR DESCRIPTION
Microprofile metrics 2.3 tests. Things I covered:
- new SimpleTimed metric
- new withOptional* methods for MetadataBuilder
- new MetricID.getTagsAsArray method
- new MetricType.fromClassName method

One thing I didn't cover:
- New metric "REST.request". This is optional and I believe isn't implemented?
