### PR TITLE
[THORN-2561] CDI into ClientHeadersFactory

### DIFF
--- a/microprofile/microprofile-rest-client-1.4/pom.xml
+++ b/microprofile/microprofile-rest-client-1.4/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.thorntail.ts</groupId>
+        <artifactId>ts-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>ts-microprofile-rest-client-1.4</artifactId>
+    <packaging>war</packaging>
+
+    <name>Thorntail TS: MicroProfile Rest Client 1.4</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>jaxrs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>microprofile-restclient</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>arquillian</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/RestApplication.java
+++ b/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/RestApplication.java
@@ -1,0 +1,8 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v14;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/rest")
+public class RestApplication extends Application {
+}

--- a/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/ClientHeadersClient.java
+++ b/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/ClientHeadersClient.java
@@ -6,7 +6,6 @@ import javax.ws.rs.Path;
 import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-@Path("/")
 @RegisterRestClient(baseUri = "http://localhost:8080")
 @RegisterClientHeaders(ClientHeadersFactoryImpl.class)
 public interface ClientHeadersClient {

--- a/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/ClientHeadersClient.java
+++ b/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/ClientHeadersClient.java
@@ -1,0 +1,17 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v14.clientheaders;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/")
+@RegisterRestClient(baseUri = "http://localhost:8080")
+@RegisterClientHeaders(ClientHeadersFactoryImpl.class)
+public interface ClientHeadersClient {
+
+    @GET
+    @Path("/rest/headers")
+    String getHeaders();
+}

--- a/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/ClientHeadersFactoryImpl.java
+++ b/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/ClientHeadersFactoryImpl.java
@@ -1,0 +1,23 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v14.clientheaders;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+
+
+public class ClientHeadersFactoryImpl implements ClientHeadersFactory {
+
+    @Inject
+    Counter counter;
+
+    @Override
+    public MultivaluedMap<String, String> update(MultivaluedMap<String, String> inbound, MultivaluedMap<String, String> outbound) {
+
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add("FOO", "BAR");
+        headers.add("INJECTED_COUNT", counter != null ? Integer.toString(counter.count()) : "is_null");
+        return headers;
+    }
+}

--- a/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/ClientResource.java
+++ b/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/ClientResource.java
@@ -1,0 +1,21 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v14.clientheaders;
+
+import java.net.URL;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+@Path("/")
+public class ClientResource {
+
+    @GET
+    @Path("/client")
+    public String headers() throws Exception {
+        ClientHeadersClient client = RestClientBuilder.newBuilder()
+                .baseUrl(new URL("http://localhost:8080"))
+                .build(ClientHeadersClient.class);
+        return client.getHeaders();
+    }
+}

--- a/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/ClientResource.java
+++ b/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/ClientResource.java
@@ -7,11 +7,10 @@ import javax.ws.rs.Path;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 
-@Path("/")
+@Path("/client")
 public class ClientResource {
 
     @GET
-    @Path("/client")
     public String headers() throws Exception {
         ClientHeadersClient client = RestClientBuilder.newBuilder()
                 .baseUrl(new URL("http://localhost:8080"))

--- a/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/Counter.java
+++ b/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/Counter.java
@@ -1,0 +1,15 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v14.clientheaders;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Counter {
+
+    private static final AtomicInteger COUNT = new AtomicInteger(0);
+
+    public int count() {
+        return COUNT.incrementAndGet();
+    }
+}

--- a/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/SimpleResource.java
+++ b/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/SimpleResource.java
@@ -1,0 +1,23 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v14.clientheaders;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+
+@Path("/")
+public class SimpleResource {
+    @Context
+    HttpHeaders headers;
+
+    @GET
+    @Path("/headers")
+    public JsonObject getHeaders() {
+        final JsonObjectBuilder builder = Json.createObjectBuilder();
+        headers.getRequestHeaders().forEach((key, value) -> builder.add(key, String.valueOf(value.get(0))));
+        return builder.build();
+    }
+}

--- a/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/SimpleResource.java
+++ b/microprofile/microprofile-rest-client-1.4/src/main/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/clientheaders/SimpleResource.java
@@ -8,13 +8,12 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 
-@Path("/")
+@Path("/headers")
 public class SimpleResource {
     @Context
     HttpHeaders headers;
 
     @GET
-    @Path("/headers")
     public JsonObject getHeaders() {
         final JsonObjectBuilder builder = Json.createObjectBuilder();
         headers.getRequestHeaders().forEach((key, value) -> builder.add(key, String.valueOf(value.get(0))));

--- a/microprofile/microprofile-rest-client-1.4/src/test/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/HeadersViaFactoryTest.java
+++ b/microprofile/microprofile-rest-client-1.4/src/test/java/org/wildfly/swarm/ts/microprofile/rest/client/v14/HeadersViaFactoryTest.java
@@ -1,0 +1,36 @@
+package org.wildfly.swarm.ts.microprofile.rest.client.v14;
+
+import java.io.IOException;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class HeadersViaFactoryTest {
+
+    @Test
+    @RunAsClient
+    public void checkHeaders() throws IOException {
+        String response = Request.Get("http://localhost:8080/rest/client").execute().returnContent().asString();
+        checkJsonResponse(response);
+    }
+
+    private void checkJsonResponse(String response) {
+        JsonElement json = JsonParser.parseString(response);
+        assertThat(json.isJsonObject()).isTrue();
+        assertThat(json.getAsJsonObject().has("FOO")).isTrue();
+        assertThat(json.getAsJsonObject().get("FOO").getAsString()).isEqualTo("BAR");
+
+        assertThat(json.getAsJsonObject().has("INJECTED_COUNT")).isTrue();
+        assertThat(json.getAsJsonObject().get("INJECTED_COUNT").getAsString()).isEqualTo("1").as("Counter is injected to ClientHeadersFactory implementation");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <module>microprofile/microprofile-rest-client-1.0</module>
         <module>microprofile/microprofile-rest-client-1.2</module>
         <module>microprofile/microprofile-rest-client-1.3</module>
+        <module>microprofile/microprofile-rest-client-1.4</module>
         <module>microprofile/opentracing-fault-tolerance</module>
         <module>microprofile/opentracing-restclient</module>
 


### PR DESCRIPTION
Draft of MP 3.3 RestClient-1.4 tests.
Source: https://github.com/eclipse/microprofile-rest-client/milestone/7?closed=1
Tests are focused on usage of annotation @RestClient. There is no extra value in usage on method and constructor. Prior this worked as expected and any other usage of annotation fails at build time, even in IDE. I found no other topic to test in 1.4 specification. Even this annotation testing is probably quite useless.