### PR TITLE
[THORN-2561] circuitBreaker, fallback

### DIFF
--- a/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/circuitbreaker/CircuitBreakerService.java
+++ b/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/circuitbreaker/CircuitBreakerService.java
@@ -1,0 +1,205 @@
+package org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.circuitbreaker;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.MyConnection;
+import org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.MyException;
+
+@Asynchronous // all is async
+@ApplicationScoped
+public class CircuitBreakerService {
+
+    @CircuitBreaker(failOn = Exception.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> exception_failOnE(boolean fail) throws Exception {
+        if (fail) {
+            throw new Exception("Simulated Exception");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from exception_failOnE";
+            }
+        });
+    }
+
+    @CircuitBreaker(failOn = MyException.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> exception_failOnMyE(boolean fail) throws Exception {
+        if (fail) {
+            throw new Exception("Simulated Exception");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from exception_failOnMyE";
+            }
+        });
+    }
+
+    @CircuitBreaker(failOn = Exception.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> myException_failOnE(boolean fail) throws Exception {
+        if (fail) {
+            throw new MyException("Simulated MyException");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException_failOnE";
+            }
+        });
+    }
+
+    @CircuitBreaker(failOn = MyException.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> myException_failOnMyE(boolean fail) throws Exception {
+        if (fail) {
+            throw new MyException("Simulated MyException");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException_failOnMyE";
+            }
+        });
+    }
+
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> myException_noCB(boolean fail) throws Exception {
+        if (fail) {
+            throw new MyException("Simulated MyException");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException_noCB";
+            }
+        });
+    }
+
+    @CircuitBreaker
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> myException_blankCB(boolean fail) throws Exception {
+        if (fail) {
+            throw new MyException("Simulated MyException");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException_blankCB";
+            }
+        });
+    }
+
+    @CircuitBreaker(failOn = Exception.class, skipOn = MyException.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> exception_failOnE_skipOnMyE(boolean fail) throws Exception {
+        if (fail) {
+            throw new Exception("Simulated Exception");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from exception_failOnE_skipOnMyE";
+            }
+        });
+    }
+
+    @CircuitBreaker(failOn = Exception.class, skipOn = MyException.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> myException_failOnE_skipOnMyE(boolean fail) throws Exception {
+        if (fail) {
+            throw new MyException("Simulated MyException");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException_failOnE_skipOnMyE";
+            }
+        });
+    }
+
+    @CircuitBreaker(skipOn = MyException.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> exception_skipOnMyE(boolean fail) throws Exception {
+        if (fail) {
+            throw new Exception("Simulated Exception");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from exception_skipOnMyE";
+            }
+        });
+    }
+
+    @CircuitBreaker(skipOn = MyException.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> myException_skipOnMyE(boolean fail) throws Exception {
+        if (fail) {
+            throw new MyException("Simulated MyException");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException_skipOnMyE";
+            }
+        });
+    }
+
+    @CircuitBreaker(failOn = MyException.class, skipOn = Exception.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> exception_failOnMyE_skipOnE(boolean fail) throws Exception {
+        if (fail) {
+            throw new Exception("Simulated Exception");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from exception_failOnMyE_skipOnE";
+            }
+        });
+    }
+
+    @CircuitBreaker(failOn = MyException.class, skipOn = Exception.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> myException_failOnMyE_skipOnE(boolean fail) throws Exception {
+        if (fail) {
+            throw new MyException("Simulated MyException");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException_failOnMyE_skipOnE";
+            }
+        });
+    }
+
+    private CompletionStage<MyConnection> processFallback(boolean fail) {
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Fallback Hello";
+            }
+        });
+    }
+}

--- a/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/circuitbreaker/CircuitBreakerServlet.java
+++ b/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/circuitbreaker/CircuitBreakerServlet.java
@@ -1,0 +1,74 @@
+package org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.circuitbreaker;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.MyConnection;
+
+@WebServlet("/circuitbreaker")
+public class CircuitBreakerServlet extends HttpServlet {
+    @Inject
+    private CircuitBreakerService service;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException {
+        String operation = req.getParameter("operation");
+        boolean fail = Boolean.parseBoolean(req.getParameter("fail"));
+
+        CompletionStage<MyConnection> completionStage = null;
+        try {
+            switch (operation) {
+                case "exception-failone":
+                    completionStage = service.exception_failOnE(fail);
+                    break;
+                case "exception-failonmye":
+                    completionStage = service.exception_failOnMyE(fail);
+                    break;
+                case "myexception-failone":
+                    completionStage = service.myException_failOnE(fail);
+                    break;
+                case "myexception-failonmye":
+                    completionStage = service.myException_failOnMyE(fail);
+                    break;
+                case "myexception-nocb":
+                    completionStage = service.myException_noCB(fail);
+                    break;
+                case "myexception-blankcb":
+                    completionStage = service.myException_blankCB(fail);
+                    break;
+                case "exception-failone-skiponmye":
+                    completionStage = service.exception_failOnE_skipOnMyE(fail);
+                    break;
+                case "myexception-failone-skiponmye":
+                    completionStage = service.myException_failOnE_skipOnMyE(fail);
+                    break;
+                case "exception-skiponmye":
+                    completionStage = service.exception_skipOnMyE(fail);
+                    break;
+                case "myexception-skiponmye":
+                    completionStage = service.myException_skipOnMyE(fail);
+                    break;
+                case "exception-failonmye-skipone":
+                    completionStage = service.exception_failOnMyE_skipOnE(fail);
+                    break;
+                case "myexception-failonmye-skipone":
+                    completionStage = service.myException_failOnMyE_skipOnE(fail);
+                    break;
+            }
+            resp.getWriter().print(completionStage != null ?
+                                           completionStage.toCompletableFuture().get().getData() :
+                                           "completion stage is null");
+        } catch (ExecutionException e) {
+            throw new ServletException("in CircuitBreakerServlet.doGet ExecutionException: " + e);
+        } catch (Throwable t) {
+            throw new ServletException("in CircuitBreakerServlet.doGet Throwable" + t);
+        }
+    }
+}

--- a/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/fallback/FallbackService.java
+++ b/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/fallback/FallbackService.java
@@ -1,0 +1,121 @@
+package org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.fallback;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.MyConnection;
+import org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.MyException;
+
+@Asynchronous // all is async
+@ApplicationScoped
+public class FallbackService {
+
+    public CompletionStage<MyConnection> exception(boolean fail) throws Exception {
+        if (fail) {
+            throw new Exception("Simulated Exception");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from exception";
+            }
+        });
+    }
+
+    public CompletionStage<MyConnection> myException(boolean fail) throws Exception {
+        if (fail) {
+            throw new MyException("Simulated MyException");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException";
+            }
+        });
+    }
+
+    @Fallback(fallbackMethod = "processFallback", skipOn = MyException.class)
+    public CompletionStage<MyConnection> exception_skipOnMyE(boolean fail) throws Exception {
+        if (fail) {
+            throw new Exception("Simulated Exception");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from exception_skipOnMyE";
+            }
+        });
+    }
+
+    @Fallback(fallbackMethod = "processFallback", applyOn = Exception.class, skipOn = MyException.class)
+    public CompletionStage<MyConnection> exception_applyOnE_skipOnMyE(boolean fail) throws Exception {
+        if (fail) {
+            throw new Exception("Simulated Exception");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from exception_applyOnE_skipOnMyE";
+            }
+        });
+    }
+
+    @Fallback(fallbackMethod = "processFallback", applyOn = Exception.class, skipOn = MyException.class)
+    public CompletionStage<MyConnection> myException_applyOnE_skipOnMyE(boolean fail) throws Exception {
+        if (fail) {
+            throw new MyException("Simulated MyException");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException_applyOnE_skipOnMyE";
+            }
+        });
+    }
+
+    @Fallback(fallbackMethod = "processFallback", applyOn = MyException.class, skipOn = Exception.class)
+    public CompletionStage<MyConnection> exception_applyOnMyE_skipOnE(boolean fail) throws Exception {
+        if (fail) {
+            throw new Exception("Simulated Exception");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from exception_applyOnMyE_skipOnE";
+            }
+        });
+    }
+
+    @Fallback(fallbackMethod = "processFallback", applyOn = MyException.class, skipOn = Exception.class)
+    public CompletionStage<MyConnection> myException_applyOnMyE_skipOnE(boolean fail) throws Exception {
+        if (fail) {
+            throw new MyException("Simulated MyException");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException_applyOnMyE_skipOnE";
+            }
+        });
+    }
+
+    private CompletionStage<MyConnection> processFallback(boolean fail) {
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Fallback Hello";
+            }
+        });
+    }
+}

--- a/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/fallback/FallbackServlet.java
+++ b/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/fallback/FallbackServlet.java
@@ -1,0 +1,59 @@
+package org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.fallback;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.MyConnection;
+
+@WebServlet("/fallback")
+public class FallbackServlet extends HttpServlet {
+    @Inject
+    private FallbackService service;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException {
+        String operation = req.getParameter("operation");
+        boolean fail = Boolean.parseBoolean(req.getParameter("fail"));
+
+        CompletionStage<MyConnection> completionStage = null;
+        try {
+            switch (operation) {
+                case "exception":
+                    completionStage = service.exception(fail);
+                    break;
+                case "myexception":
+                    completionStage = service.myException(fail);
+                    break;
+                case "exception-skiponmye":
+                    completionStage = service.exception_skipOnMyE(fail);
+                    break;
+                case "exception-applyone-skiponmye":
+                    completionStage = service.exception_applyOnE_skipOnMyE(fail);
+                    break;
+                case "myexception-applyone-skiponmye":
+                    completionStage = service.myException_applyOnE_skipOnMyE(fail);
+                    break;
+                case "exception-applyonmye-skipone":
+                    completionStage = service.exception_applyOnMyE_skipOnE(fail);
+                    break;
+                case "myexception-applyonmye-skipone":
+                    completionStage = service.myException_applyOnMyE_skipOnE(fail);
+                    break;
+            }
+            resp.getWriter().print(completionStage != null ?
+                                           completionStage.toCompletableFuture().get().getData() :
+                                           "completion stage is null");
+        } catch (ExecutionException e) {
+            throw new ServletException("in FallbackServlet.doGet ExecutionException: " + e);
+        } catch (Throwable t) {
+            throw new ServletException("in FallbackServlet.doGet Throwable" + t);
+        }
+    }
+}

--- a/microprofile/microprofile-fault-tolerance-2.1/src/test/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/CircuitBreakerTest.java
+++ b/microprofile/microprofile-fault-tolerance-2.1/src/test/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/CircuitBreakerTest.java
@@ -1,0 +1,149 @@
+package org.wildfly.swarm.ts.microprofile.fault.tolerance.v21;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class CircuitBreakerTest {
+
+    private static final String FALLBACK_HELLO = "Fallback Hello";
+
+    @Test
+    @RunAsClient
+    @InSequence(1)
+    public void exception_failOnE() throws IOException, InterruptedException {
+        testCircuitBreaker("http://localhost:8080/circuitbreaker?operation=exception-failone",
+                           20, 10, FALLBACK_HELLO,
+                           "Hello from exception_failOnE");
+    }
+
+    @Test // failsOn takes only MyException, so Exception goes through (to fallback), 21th call is OK
+    @RunAsClient
+    @InSequence(2)
+    public void exception_failOnMyE() throws IOException, InterruptedException {
+        testCircuitBreaker("http://localhost:8080/circuitbreaker?operation=exception-failonmye",
+                           20, 0, FALLBACK_HELLO,
+                           "Hello from exception_failOnMyE");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(3)
+    public void myException_failOnE() throws IOException, InterruptedException {
+        testCircuitBreaker("http://localhost:8080/circuitbreaker?operation=myexception-failone",
+                           20, 10, FALLBACK_HELLO,
+                           "Hello from myException_failOnE");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(4)
+    public void myException_failOnMyE() throws IOException, InterruptedException {
+        testCircuitBreaker("http://localhost:8080/circuitbreaker?operation=myexception-failonmye",
+                           20, 10, FALLBACK_HELLO,
+                           "Hello from myException_failOnMyE");
+    }
+
+    @Test // no circuit breaker -> just fallback, 21th call is OK
+    @RunAsClient
+    @InSequence(5)
+    public void myException_noCB() throws IOException, InterruptedException {
+        testCircuitBreaker("http://localhost:8080/circuitbreaker?operation=myexception-nocb",
+                           20, 0, FALLBACK_HELLO,
+                           "Hello from myException_noCB");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(6)
+    public void myException_blankCB() throws IOException, InterruptedException {
+        testCircuitBreaker("http://localhost:8080/circuitbreaker?operation=myexception-blankcb",
+                           20, 10, FALLBACK_HELLO,
+                           "Hello from myException_blankCB");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(7)
+    public void exception_failOnE_skipOnMyE() throws IOException, InterruptedException {
+        testCircuitBreaker("http://localhost:8080/circuitbreaker?operation=exception-failone-skiponmye",
+                           20, 10, FALLBACK_HELLO,
+                           "Hello from exception_failOnE_skipOnMyE");
+    }
+
+    @Test // MyException is skipped by skipOn MyException, 21th call is OK
+    @RunAsClient
+    @InSequence(8)
+    public void myException_failOnE_skipOnMyE() throws IOException, InterruptedException {
+        testCircuitBreaker("http://localhost:8080/circuitbreaker?operation=myexception-failone-skiponmye",
+                           20, 0, FALLBACK_HELLO,
+                           "Hello from myException_failOnE_skipOnMyE");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(9)
+    public void exception_skipOnMyE() throws IOException, InterruptedException {
+        testCircuitBreaker("http://localhost:8080/circuitbreaker?operation=exception-skiponmye",
+                           20, 10, FALLBACK_HELLO,
+                           "Hello from exception_skipOnMyE");
+    }
+
+    @Test // skipOp MyException causes only fallback to take effect, 21th call is OK
+    @RunAsClient
+    @InSequence(10)
+    public void myException_skipOnMyE() throws IOException, InterruptedException {
+        testCircuitBreaker("http://localhost:8080/circuitbreaker?operation=myexception-skiponmye",
+                           20, 0, FALLBACK_HELLO,
+                           "Hello from myException_skipOnMyE");
+    }
+
+    @Test // Exception is skipped by skipOn Exception, 21th call is OK
+    @RunAsClient
+    @InSequence(11)
+    public void exception_failOnMyE_skipOnE() throws IOException, InterruptedException {
+        testCircuitBreaker("http://localhost:8080/circuitbreaker?operation=exception-failonmye-skipone",
+                           20, 0, FALLBACK_HELLO,
+                           "Hello from exception_failOnMyE_skipOnE");
+    }
+
+    @Test // MyException is skipped by skipOn Exception, 21th call is OK
+    @RunAsClient
+    @InSequence(12)
+    public void myException_failOnMyE_skipOnE() throws IOException, InterruptedException {
+        testCircuitBreaker("http://localhost:8080/circuitbreaker?operation=myexception-failonmye-skipone",
+                           20, 0, FALLBACK_HELLO,
+                           "Hello from myException_failOnMyE_skipOnE");
+    }
+
+    private static void testCircuitBreaker(String url, int failCalls, int okCalls, String expectedFallbackResponse, String expectedOkResponse) throws IOException, InterruptedException {
+        // call e.g. 20x fail URL, circuit breaker is OPEN
+        for (int i = 0; i < failCalls; i++) {
+            String response = Request.Get(url + "&fail=true").execute().returnContent().asString();
+            assertThat(response).isEqualTo(expectedFallbackResponse);
+        }
+        // call e.g. 10x correct URL on open circuit breaker -> still returns fallback response
+        for (int i = 0; i < okCalls; i++) {
+            String response = Request.Get(url).execute().returnContent().asString();
+            assertThat(response).isEqualTo(expectedFallbackResponse);
+        }
+        // the window of 20 calls now contains 10 fail and 10 correct responses, this equals 0.5 failureRatio
+        // @CircuitBreaker.delay is 5 seconds, then circuit breaker is CLOSED and OK response is returned
+        await().atMost(5 + 1, TimeUnit.SECONDS).untilAsserted(() -> {
+            String response = Request.Get(url).execute().returnContent().asString();
+            assertThat(response).isEqualTo(expectedOkResponse);
+        });
+    }
+}

--- a/microprofile/microprofile-fault-tolerance-2.1/src/test/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/FallbackTest.java
+++ b/microprofile/microprofile-fault-tolerance-2.1/src/test/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/FallbackTest.java
@@ -1,0 +1,103 @@
+package org.wildfly.swarm.ts.microprofile.fault.tolerance.v21;
+
+import java.io.IOException;
+
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class FallbackTest {
+
+    private static final String FALLBACK_HELLO = "Fallback Hello";
+
+    @Test // no fallback, throwing Exception causes expected fail
+    @RunAsClient
+    @InSequence(1)
+    public void exception() throws IOException {
+        testFallback("http://localhost:8080/fallback?operation=exception",
+                     "Hello from exception", true);
+    }
+
+    @Test // no fallback, throwing MyException causes expected fail
+    @RunAsClient
+    @InSequence(2)
+    public void myException() throws IOException {
+        testFallback("http://localhost:8080/fallback?operation=myexception",
+                     "Hello from myException", true);
+    }
+
+    @Test // skipOn has no effect, fallback applies
+    @RunAsClient
+    @InSequence(3)
+    public void exception_skipOnMyE() throws IOException {
+        testFallback("http://localhost:8080/fallback?operation=exception-skiponmye",
+                     "Hello from exception_skipOnMyE", false);
+    }
+
+    @Test // skipOn has no effect, fallback applies
+    @RunAsClient
+    @InSequence(4)
+    public void exception_applyOnE_skipOnMyE() throws IOException {
+        testFallback("http://localhost:8080/fallback?operation=exception-applyone-skiponmye",
+                     "Hello from exception_applyOnE_skipOnMyE", false);
+    }
+
+    @Test // skipOn MyException UNBLOCKS MyException, fallback is not applied
+    @RunAsClient
+    @InSequence(5)
+    public void myException_applyOnE_skipOnMyE() throws IOException {
+        testFallback("http://localhost:8080/fallback?operation=myexception-applyone-skiponmye",
+                     "Hello from myException_applyOnE_skipOnMyE", true);
+    }
+
+    @Test // skipOn Exception UNBLOCKS Exception, fallback is not applied
+    @RunAsClient
+    @InSequence(6)
+    public void exception_applyOnMyE_skipOnE() throws IOException {
+        testFallback("http://localhost:8080/fallback?operation=exception-applyonmye-skipone",
+                     "Hello from exception_applyOnMyE_skipOnE", true);
+    }
+
+    // skipOn Exception takes effect on MyException as it is ancestor, fallback is not applied
+    // Note: skipOn has higher priority over applyOn
+    @Test
+    @RunAsClient
+    @InSequence(7)
+    public void myException_applyOnMyE_skipOnE() throws IOException {
+        testFallback("http://localhost:8080/fallback?operation=myexception-applyonmye-skipone",
+                     "Hello from myException_applyOnMyE_skipOnE", true);
+    }
+
+    private static void testFallback(String url, String expectedOkResponse, boolean expectingFail) throws IOException {
+        String response = Request.Get(url).execute().returnContent().asString();
+        assertThat(response).isEqualTo(expectedOkResponse);
+
+        boolean exceptionOccurred = false;
+        final String failUrl = url + "&fail=true";
+        try {
+            response = Request.Get(failUrl).execute().returnContent().asString();
+            assertThat(response).isEqualTo(FALLBACK_HELLO);
+        } catch (Exception e) {
+            exceptionOccurred = true;
+        }
+
+        if (expectingFail) {
+            if (!exceptionOccurred) {
+                fail("Request to '" + failUrl + "' should cause exception! But response: " + response);
+            }
+        } else {
+            if (exceptionOccurred) {
+                fail("Request to '" + failUrl + "' should NOT cause exception!");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Waiting for @mirostary with his tests for @Retry with retryOn and abortOn.
The idea is that tests are in sequence and the higher the sequence number the more difficult tests.
Structure is: [exception|myException]_<[failOn|applyOn][E|MyE]>_<[skipOn][E|MyE]>
Meaning there is Exception or MyException thrown, then skipOn (Exception or MyException) takes effect (because its higher priority than failOn or applyOn). Then failOn or applyOn takes effect on Exception or MyException.

In CircuitBreakerTests there are typically 20 fail calls followed by 10 OK calls. According to policy the CircuitBreaker catches these fail calls and the windows (20) closes the circuit after rate of successful responses is higher than 50%. This does not apply in case the breaker does not recognize the exception, so there are 20 fail calls followed by even 1 successful reply.

FallbackTest is simpler. It either recognizes fail call and returns "Fallback Hello" or the exception goes through.

Tests cover significant combinations when skipOn, failOn or applyOn use general exception and its subtype myException.