### PR TITLE
[THORN-2561] The Retry.retryOn and abortOn attributes no longer ignore Throwable.class

### DIFF
--- a/microprofile/microprofile-fault-tolerance-2.1/pom.xml
+++ b/microprofile/microprofile-fault-tolerance-2.1/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.thorntail.ts</groupId>
+        <artifactId>ts-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>ts-microprofile-fault-tolerance-2.1</artifactId>
+    <packaging>war</packaging>
+
+    <name>Thorntail TS: MicroProfile Fault Tolerance 2.1</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>microprofile-fault-tolerance</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>undertow</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>arquillian</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/MyConnection.java
+++ b/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/MyConnection.java
@@ -1,0 +1,5 @@
+package org.wildfly.swarm.ts.microprofile.fault.tolerance.v21;
+
+public interface MyConnection {
+    public String getData();
+}

--- a/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/MyException.java
+++ b/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/MyException.java
@@ -1,0 +1,7 @@
+package org.wildfly.swarm.ts.microprofile.fault.tolerance.v21;
+
+public class MyException extends Exception {
+    public MyException(String message) {
+        super(message);
+    }
+}

--- a/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/retry/RetryService.java
+++ b/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/retry/RetryService.java
@@ -1,0 +1,165 @@
+package org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.retry;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.RequestScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.MyConnection;
+import org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.MyException;
+
+@Asynchronous // all is async with fallback method
+@RequestScoped
+public class RetryService {
+
+    private AtomicInteger counter = new AtomicInteger(0);
+
+    // First fail, second pass - there will be 1 retry before success
+    @Retry(retryOn = Throwable.class)
+    public CompletionStage<MyConnection> throwable_retryOnT() throws Throwable {
+        int invocationNumber = counter.incrementAndGet();
+        if (invocationNumber % 2 == 1) {
+            throw new Throwable("Simulated Throwable");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from throwable_retryOnT, counter: " + invocationNumber;
+            }
+        });
+    }
+
+    // First fail, second pass - there will be 1 retry before success (Throwable is parent of Exception)
+    @Retry(retryOn = Throwable.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> myException_retryOnT() throws MyException {
+        int invocationNumber = counter.incrementAndGet();
+        if (invocationNumber % 2 == 1) {
+            throw new MyException("Simulated custom Exception");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException_retryOnT, counter: " + invocationNumber;
+            }
+        });
+    }
+
+    // First call goes through and is recognized by fallback
+    @Retry(abortOn = Throwable.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> throwable_abortOnT() throws Throwable {
+        int invocationNumber = counter.incrementAndGet();
+        if (invocationNumber % 2 == 1) {
+            throw new Throwable("Simulated Throwable");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from throwable_abortOnT, counter: " + invocationNumber;
+            }
+        });
+    }
+
+    // First call goes through and is recognized by fallback (Throwable is parent of Exception)
+    @Retry(abortOn = Throwable.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> myException_abortOnT() throws MyException {
+        int invocationNumber = counter.incrementAndGet();
+        if (invocationNumber % 2 == 1) {
+            throw new MyException("Simulated custom Exception");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException_abortOnT, counter: " + invocationNumber;
+            }
+        });
+    }
+
+    // First call is Throwable = fallback
+    @Retry(retryOn = MyException.class, abortOn = Throwable.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> throwable_retryOnMyE_abortOnT() throws Throwable {
+        int invocationNumber = counter.incrementAndGet();
+        if (invocationNumber % 2 == 1) {
+            throw new Throwable("Simulated Throwable");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from throwable_retryOnMyE_abortOnT, counter: " + invocationNumber;
+            }
+        });
+    }
+
+    // First fail, second pass - there will be 1 retry before success
+    @Retry(retryOn = Throwable.class, abortOn = MyException.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> throwable_retryOnT_abortOnMyE() throws Throwable {
+        int invocationNumber = counter.incrementAndGet();
+        if (invocationNumber % 2 == 1) {
+            throw new Throwable("Simulated Throwable");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from throwable_retryOnT_abortOnMyE, counter: " + invocationNumber;
+            }
+        });
+    }
+
+    // First call goes through and is recognized by fallback (Throwable is parent of Exception)
+    @Retry(retryOn = MyException.class, abortOn = Throwable.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> myException_retryOnMyE_abortOnT() throws MyException {
+        int invocationNumber = counter.incrementAndGet();
+        if (invocationNumber % 2 == 1) {
+            throw new MyException("Simulated Exception");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException_retryOnMyE_abortOnT, counter: " + invocationNumber;
+            }
+        });
+    }
+
+    // First call goes through and is recognized by fallback(abortOn has higher priority than retryOn)
+    @Retry(retryOn = Throwable.class, abortOn = MyException.class)
+    @Fallback(fallbackMethod = "processFallback")
+    public CompletionStage<MyConnection> myException_retryOnT_abortOnMyE() throws MyException {
+        int invocationNumber = counter.incrementAndGet();
+        if (invocationNumber % 2 == 1) {
+            throw new MyException("Simulated Exception");
+        }
+
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from myException_retryOnT_abortOnMyE, counter: " + invocationNumber;
+            }
+        });
+    }
+
+    private CompletionStage<MyConnection> processFallback() {
+        int invocationNumber = counter.get();
+        return CompletableFuture.completedFuture(new MyConnection() {
+            @Override
+            public String getData() {
+                return "Hello from fallback, counter: " + invocationNumber;
+            }
+        });
+    }
+}

--- a/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/retry/RetryServlet.java
+++ b/microprofile/microprofile-fault-tolerance-2.1/src/main/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/retry/RetryServlet.java
@@ -1,0 +1,58 @@
+package org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.retry;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.wildfly.swarm.ts.microprofile.fault.tolerance.v21.MyConnection;
+
+@WebServlet("/async")
+public class RetryServlet extends HttpServlet {
+    @Inject
+    private RetryService service;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException {
+        String operation = req.getParameter("operation");
+
+        CompletionStage<MyConnection> completionStage = null;
+        try {
+            switch (operation) {
+                case "throwable-retryont":
+                    completionStage = service.throwable_retryOnT();
+                    break;
+                case "myexception-retryont":
+                    completionStage = service.myException_retryOnT();
+                    break;
+                case "throwable-abortont":
+                    completionStage = service.throwable_abortOnT();
+                    break;
+                case "myexception-abortont":
+                    completionStage = service.myException_abortOnT();
+                    break;
+                case "throwable-retryonmye-abortont":
+                    completionStage = service.throwable_retryOnMyE_abortOnT();
+                    break;
+                case "throwable-retryont-abortonmye":
+                    completionStage = service.throwable_retryOnT_abortOnMyE();
+                    break;
+                case "myexception-retryonmye-abortont":
+                    completionStage = service.myException_retryOnMyE_abortOnT();
+                    break;
+                case "myexception-retryont-abortonmye":
+                    completionStage = service.myException_retryOnT_abortOnMyE();
+                    break;
+            }
+            resp.getWriter().print(completionStage != null ?
+                                           completionStage.toCompletableFuture().get().getData() :
+                                           "completion stage is null");
+        } catch (Throwable t) {
+            throw new ServletException(t);
+        }
+    }
+}

--- a/microprofile/microprofile-fault-tolerance-2.1/src/test/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/RetryTest.java
+++ b/microprofile/microprofile-fault-tolerance-2.1/src/test/java/org/wildfly/swarm/ts/microprofile/fault/tolerance/v21/RetryTest.java
@@ -1,0 +1,82 @@
+package org.wildfly.swarm.ts.microprofile.fault.tolerance.v21;
+
+import java.io.IOException;
+
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class RetryTest {
+
+    @Test
+    @RunAsClient
+    @InSequence(1)
+    public void throwable_retryOnT() throws IOException {
+        String response = Request.Get("http://localhost:8080/async?operation=throwable-retryont").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello from throwable_retryOnT, counter: 2");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(2)
+    public void myException_retryOnT() throws IOException {
+        String response = Request.Get("http://localhost:8080/async?operation=myexception-retryont").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello from myException_retryOnT, counter: 2");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(3)
+    public void throwable_abortOnT() throws IOException {
+        String response = Request.Get("http://localhost:8080/async?operation=throwable-abortont").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello from fallback, counter: 1");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(4)
+    public void myException_abortOnT() throws IOException {
+        String response = Request.Get("http://localhost:8080/async?operation=myexception-abortont").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello from fallback, counter: 1");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(5)
+    public void throwable_retryOnMyE_abortOnT() throws IOException {
+        String response = Request.Get("http://localhost:8080/async?operation=throwable-retryonmye-abortont").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello from fallback, counter: 1");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(6)
+    public void throwable_retryOnT_abortOnMyE() throws IOException {
+        String response = Request.Get("http://localhost:8080/async?operation=throwable-retryont-abortonmye").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello from throwable_retryOnT_abortOnMyE, counter: 2");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(7)
+    public void myException_retryOnMyE_abortOnT() throws IOException {
+        String response = Request.Get("http://localhost:8080/async?operation=myexception-retryonmye-abortont").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello from fallback, counter: 1");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(8)
+    public void myException_retryOnT_abortOnMyE() throws IOException {
+        String response = Request.Get("http://localhost:8080/async?operation=myexception-retryont-abortonmye").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello from fallback, counter: 1");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
         <module>microprofile/microprofile-metrics-2.3</module>
         <module>microprofile/microprofile-fault-tolerance-1.0</module>
         <module>microprofile/microprofile-fault-tolerance-2.0</module>
+        <module>microprofile/microprofile-fault-tolerance-2.1</module>
         <module>microprofile/microprofile-openapi-1.0</module>
         <module>microprofile/microprofile-openapi-1.1</module>
         <module>microprofile/microprofile-opentracing-1.0</module>


### PR DESCRIPTION
The idea is that tests are in sequence and the higher the sequence number the more difficult tests.
Structure is: [throwable|myException]<[retryOn|abortOn][T|MyE]>
Meaning there is Throwable or MyException thrown.

Tests either recognizes fail call and returns "Fallback Hello" or successful response.
We are using AtomicInteger counter and every odd number will throw Throwable or MyException. 

Tests cover combinations of retryOn and abortOn by using Throwable and MyException.

@penehyba will provide tests on @Fallback and @CircuitBeaker in the next PR.