### PR TITLE
add tests for WildFly OpenSSL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,9 +117,11 @@
         <module>protocols/ajp</module>
         <module>protocols/https</module>
         <module>protocols/https-1way</module> <!-- same as protocols/https, but more verbose/low-level configuration -->
+        <module>protocols/https-1way-openssl</module> <!-- same as protocols/https-1way, but with WildFly OpenSSL enabled -->
         <module>protocols/https-2way</module>
         <module>protocols/https-2way-authz</module>
         <module>protocols/https-1way-elytron</module> <!-- same as protocols/https-1way, but using Elytron -->
+        <module>protocols/https-1way-openssl-elytron</module> <!-- same as protocols/https-1way-openssl, but using Elytron -->
         <module>protocols/https-2way-elytron</module> <!-- same as protocols/https-2way, but using Elytron -->
         <module>protocols/https-2way-authz-elytron</module> <!-- same as protocols/https-2way-authz, but using Elytron -->
 
@@ -148,7 +150,7 @@
         <version.com.icegreen.greenmail>1.5.11</version.com.icegreen.greenmail>
         <version.io.jaegertracing.everything>0.34.1</version.io.jaegertracing.everything>
         <version.io.jsonwebtoken.jjwt-everything>0.11.1</version.io.jsonwebtoken.jjwt-everything>
-        <version.io.thorntail>2.7.0.Final</version.io.thorntail>
+        <version.io.thorntail>2.7.1.Final-SNAPSHOT</version.io.thorntail>
         <version.jakarta.enterprise.cdi-api>2.0.2</version.jakarta.enterprise.cdi-api>
         <version.jakarta.json-api>1.1.6</version.jakarta.json-api>
         <version.junit.junit>4.13</version.junit.junit>

--- a/protocols/https-1way-openssl-elytron/pom.xml
+++ b/protocols/https-1way-openssl-elytron/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.thorntail.ts</groupId>
+        <artifactId>ts-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>ts-protocols-https-1way-openssl-elytron</artifactId>
+    <packaging>war</packaging>
+
+    <name>Thorntail TS: Protocols: HTTPS: One-way SSL with OpenSSL and Elytron</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>elytron</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>undertow</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>arquillian</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>keytool-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>server-keystore</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>generateKeyPair</goal>
+                        </goals>
+                        <configuration>
+                            <keystore>${project.build.directory}/server-keystore.jks</keystore>
+                            <storepass>server-password</storepass>
+                            <alias>server-key</alias>
+                            <keypass>server-password</keypass>
+                            <dname>CN=localhost</dname>
+                            <sigalg>SHA1withRSA</sigalg>
+                            <validity>100</validity>
+                            <keyalg>RSA</keyalg>
+                            <keysize>2048</keysize>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>server-certificate</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>exportCertificate</goal>
+                        </goals>
+                        <configuration>
+                            <keystore>${project.build.directory}/server-keystore.jks</keystore>
+                            <storepass>server-password</storepass>
+                            <alias>server-key</alias>
+                            <file>${project.build.directory}/server-cert.cer</file>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>client-truststore</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>importCertificate</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}/server-cert.cer</file>
+                            <keystore>${project.build.directory}/client-truststore.jks</keystore>
+                            <storepass>client-password</storepass>
+                            <alias>server-cert</alias>
+                            <keypass>client-password</keypass>
+                            <noprompt>true</noprompt>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/protocols/https-1way-openssl-elytron/src/main/java/org/wildfly/swarm/ts/protocols/https/oneway/openssl/elytron/HelloServlet.java
+++ b/protocols/https-1way-openssl-elytron/src/main/java/org/wildfly/swarm/ts/protocols/https/oneway/openssl/elytron/HelloServlet.java
@@ -1,0 +1,15 @@
+package org.wildfly.swarm.ts.protocols.https.oneway.openssl.elytron;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet("/")
+public class HelloServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.getWriter().print("Hello on port " + req.getLocalPort() + ", secure: " + req.isSecure());
+    }
+}

--- a/protocols/https-1way-openssl-elytron/src/main/resources/project-defaults.yml
+++ b/protocols/https-1way-openssl-elytron/src/main/resources/project-defaults.yml
@@ -1,0 +1,28 @@
+thorntail:
+  elytron:
+    key-stores:
+      my-key-store:
+        path: ${project.build.directory}/server-keystore.jks
+        type: JKS
+        credential-reference:
+          clear-text: server-password
+    key-managers:
+      my-key-manager:
+        key-store: my-key-store
+        alias-filter: server-key
+        credential-reference:
+          clear-text: server-password
+    server-ssl-contexts:
+      my-server-ssl-context:
+        key-manager: my-key-manager
+        protocols:
+        - TLSv1.2
+        # enables WildFly OpenSSL
+        providers: openssl
+  undertow:
+    servers:
+      default-server:
+        https-listeners:
+          my-https-listener:
+            ssl-context: my-server-ssl-context
+            socket-binding: https

--- a/protocols/https-1way-openssl-elytron/src/test/java/org/wildfly/swarm/ts/protocols/https/oneway/openssl/elytron/Https1wayOpensslElytronTest.java
+++ b/protocols/https-1way-openssl-elytron/src/test/java/org/wildfly/swarm/ts/protocols/https/oneway/openssl/elytron/Https1wayOpensslElytronTest.java
@@ -1,0 +1,71 @@
+package org.wildfly.swarm.ts.protocols.https.oneway.openssl.elytron;
+
+import org.apache.http.client.fluent.Executor;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContexts;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import java.io.File;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class Https1wayOpensslElytronTest {
+    private static final String[] SUPPORTED_PROTOCOLS = {"TLSv1.2"};
+
+    @Test
+    @RunAsClient
+    public void http() throws IOException {
+        String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello on port 8080, secure: false");
+    }
+
+    @Test
+    @RunAsClient
+    public void https() throws IOException, GeneralSecurityException {
+        SSLContext sslContext = SSLContexts.custom()
+                .loadTrustMaterial(new File("target/client-truststore.jks"), "client-password".toCharArray())
+                .build();
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
+                SUPPORTED_PROTOCOLS, null, new DefaultHostnameVerifier());
+        try (CloseableHttpClient httpClient = HttpClients.custom()
+                .setSSLSocketFactory(sslSocketFactory)
+                .build()) {
+
+            String response = Executor.newInstance(httpClient)
+                    .execute(Request.Get("https://localhost:8443/"))
+                    .returnContent().asString();
+            assertThat(response).isEqualTo("Hello on port 8443, secure: true");
+        }
+    }
+
+    @Test
+    @RunAsClient
+    public void https_serverCertificateUnknownToClient() throws IOException {
+        SSLContext sslContext = SSLContexts.createDefault();
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
+                SUPPORTED_PROTOCOLS, null, new DefaultHostnameVerifier());
+        try (CloseableHttpClient httpClient = HttpClients.custom()
+                .setSSLSocketFactory(sslSocketFactory)
+                .build()) {
+
+            assertThatThrownBy(() -> {
+                Executor.newInstance(httpClient).execute(Request.Get("https://localhost:8443/"));
+            }).isExactlyInstanceOf(SSLHandshakeException.class);
+        }
+    }
+}

--- a/protocols/https-1way-openssl/pom.xml
+++ b/protocols/https-1way-openssl/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.thorntail.ts</groupId>
+        <artifactId>ts-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>ts-protocols-https-1way-openssl</artifactId>
+    <packaging>war</packaging>
+
+    <name>Thorntail TS: Protocols: HTTPS: One-way SSL with OpenSSL</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>management</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>undertow</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>arquillian</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>keytool-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>server-keystore</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>generateKeyPair</goal>
+                        </goals>
+                        <configuration>
+                            <keystore>${project.build.directory}/server-keystore.jks</keystore>
+                            <storepass>server-password</storepass>
+                            <alias>server-key</alias>
+                            <keypass>server-password</keypass>
+                            <dname>CN=localhost</dname>
+                            <sigalg>SHA1withRSA</sigalg>
+                            <validity>100</validity>
+                            <keyalg>RSA</keyalg>
+                            <keysize>2048</keysize>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>server-certificate</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>exportCertificate</goal>
+                        </goals>
+                        <configuration>
+                            <keystore>${project.build.directory}/server-keystore.jks</keystore>
+                            <storepass>server-password</storepass>
+                            <alias>server-key</alias>
+                            <file>${project.build.directory}/server-cert.cer</file>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>client-truststore</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>importCertificate</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}/server-cert.cer</file>
+                            <keystore>${project.build.directory}/client-truststore.jks</keystore>
+                            <storepass>client-password</storepass>
+                            <alias>server-cert</alias>
+                            <keypass>client-password</keypass>
+                            <noprompt>true</noprompt>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/protocols/https-1way-openssl/src/main/java/org/wildfly/swarm/ts/protocols/https/oneway/openssl/HelloServlet.java
+++ b/protocols/https-1way-openssl/src/main/java/org/wildfly/swarm/ts/protocols/https/oneway/openssl/HelloServlet.java
@@ -1,0 +1,15 @@
+package org.wildfly.swarm.ts.protocols.https.oneway.openssl;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet("/")
+public class HelloServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.getWriter().print("Hello on port " + req.getLocalPort() + ", secure: " + req.isSecure());
+    }
+}

--- a/protocols/https-1way-openssl/src/main/resources/project-defaults.yml
+++ b/protocols/https-1way-openssl/src/main/resources/project-defaults.yml
@@ -1,0 +1,18 @@
+thorntail:
+  management:
+    security-realms:
+      my-ssl-realm:
+        ssl-server-identity:
+          keystore-path: ${project.build.directory}/server-keystore.jks
+          keystore-password: server-password
+          alias: server-key
+          key-password: server-password
+          # enables WildFly OpenSSL
+          protocol: openssl.TLS
+  undertow:
+    servers:
+      default-server:
+        https-listeners:
+          my-https-listener:
+            security-realm: my-ssl-realm
+            socket-binding: https

--- a/protocols/https-1way-openssl/src/test/java/org/wildfly/swarm/ts/protocols/https/oneway/openssl/Https1wayOpensslTest.java
+++ b/protocols/https-1way-openssl/src/test/java/org/wildfly/swarm/ts/protocols/https/oneway/openssl/Https1wayOpensslTest.java
@@ -1,0 +1,68 @@
+package org.wildfly.swarm.ts.protocols.https.oneway.openssl;
+
+import org.apache.http.client.fluent.Executor;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.TrustAllStrategy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContexts;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import java.io.File;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class Https1wayOpensslTest {
+    @Test
+    @RunAsClient
+    public void http() throws IOException {
+        String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
+        assertThat(response).isEqualTo("Hello on port 8080, secure: false");
+    }
+
+    @Test
+    @RunAsClient
+    public void https() throws IOException, GeneralSecurityException {
+        SSLContext sslContext = SSLContexts.custom()
+                .loadTrustMaterial(new File("target/client-truststore.jks"), "client-password".toCharArray())
+                .build();
+        try (CloseableHttpClient httpClient = HttpClients.custom()
+                .setSSLContext(sslContext)
+                .setSSLHostnameVerifier(new DefaultHostnameVerifier())
+                .build()) {
+
+            String response = Executor.newInstance(httpClient)
+                    .execute(Request.Get("https://localhost:8443/"))
+                    .returnContent().asString();
+            assertThat(response).isEqualTo("Hello on port 8443, secure: true");
+        }
+    }
+
+    @Test
+    @RunAsClient
+    public void https_serverCertificateUnknownToClient() throws IOException {
+        SSLContext sslContext = SSLContexts.createDefault();
+        try (CloseableHttpClient httpClient = HttpClients.custom()
+                .setSSLContext(sslContext)
+                .setSSLHostnameVerifier(new DefaultHostnameVerifier())
+                .build()) {
+
+            assertThatThrownBy(() -> {
+                Executor.newInstance(httpClient).execute(Request.Get("https://localhost:8443/"));
+            }).isExactlyInstanceOf(SSLHandshakeException.class);
+        }
+    }
+}


### PR DESCRIPTION
These tests are copied from `https-1way[-elytron]` tests,
the only modification is enabling WildFly OpenSSL.