### PR TITLE
fix servlet line separator expectations in tests

### DIFF
--- a/hollow-jar/web/src/main/java/org/wildfly/swarm/ts/hollow/jar/web/HelloServlet.java
+++ b/hollow-jar/web/src/main/java/org/wildfly/swarm/ts/hollow/jar/web/HelloServlet.java
@@ -19,7 +19,7 @@ public class HelloServlet extends HttpServlet {
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         String name = req.getParameter("name");
         PrintWriter writer = resp.getWriter();
-        writer.print("Servlet says: Hello, " + name + "!\n");
+        writer.println("Servlet says: Hello, " + name + "!");
         writer.print("Init param:" + initParam);
     }
 }

--- a/hollow-jar/web/src/test/java/org/wildfly/swarm/ts/hollow/jar/web/WebHollowJarIT.java
+++ b/hollow-jar/web/src/test/java/org/wildfly/swarm/ts/hollow/jar/web/WebHollowJarIT.java
@@ -18,13 +18,13 @@ public class WebHollowJarIT {
     @Test
     public void testServlet() throws IOException {
         String response = Request.Get("http://localhost:8080/servlet?name=World").execute().returnContent().asString();
-        assertThat(response).isEqualTo("Servlet says: Hello, World!\nInit param:bar");
+        assertThat(response).isEqualTo("Servlet says: Hello, World!\r\nInit param:bar");
     }
 
     @Test
     public void testJpa() throws IOException {
         String response = Request.Get("http://localhost:8080/jpa").execute().returnContent().asString();
-        assertThat(response).isEqualTo("1: Hello from JPA servlet\n");
+        assertThat(response).isEqualTo("1: Hello from JPA servlet\r\n");
     }
 
     @Test

--- a/javaee/bean-validation/src/test/java/org/wildfly/swarm/ts/javaee/bean/validation/BeanValidationTest.java
+++ b/javaee/bean-validation/src/test/java/org/wildfly/swarm/ts/javaee/bean/validation/BeanValidationTest.java
@@ -18,6 +18,6 @@ public class BeanValidationTest {
     @RunAsClient
     public void test() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-        assertThat(response).isEqualTo("Violations: 0\nViolations: 1\n");
+        assertThat(response).isEqualTo("Violations: 0\r\nViolations: 1\r\n");
     }
 }

--- a/javaee/datasources/src/test/java/org/wildfly/swarm/ts/javaee/datasources/DatasourcesTest.java
+++ b/javaee/datasources/src/test/java/org/wildfly/swarm/ts/javaee/datasources/DatasourcesTest.java
@@ -18,6 +18,6 @@ public class DatasourcesTest {
     @RunAsClient
     public void test() throws IOException {
         String result = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-        assertThat(result).isEqualTo("DataSource present: true\nConnection obtained: true\n");
+        assertThat(result).isEqualTo("DataSource present: true\r\nConnection obtained: true\r\n");
     }
 }

--- a/javaee/jpa/src/test/java/org/wildfly/swarm/ts/javaee/jpa/JpaTest.java
+++ b/javaee/jpa/src/test/java/org/wildfly/swarm/ts/javaee/jpa/JpaTest.java
@@ -19,12 +19,12 @@ public class JpaTest {
     public void test() throws IOException {
         {
             String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-            assertThat(response).isEqualTo("1: Hello from servlet + JPA\n");
+            assertThat(response).isEqualTo("1: Hello from servlet + JPA\r\n");
         }
 
         {
             String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-            assertThat(response).isEqualTo("1: Hello from servlet + JPA\n2: Hello from servlet + JPA\n");
+            assertThat(response).isEqualTo("1: Hello from servlet + JPA\r\n2: Hello from servlet + JPA\r\n");
         }
     }
 }

--- a/javaee/jta/src/test/java/org/wildfly/swarm/ts/javaee/jta/JtaTest.java
+++ b/javaee/jta/src/test/java/org/wildfly/swarm/ts/javaee/jta/JtaTest.java
@@ -27,8 +27,8 @@ public class JtaTest {
     public void withTxCommit() throws IOException {
         String result = Request.Get("http://localhost:8080/with-tx-commit").execute().returnContent().asString();
         assertThat(result).isEqualTo(""
-                + Status.STATUS_NO_TRANSACTION + "\n"
-                + Status.STATUS_ACTIVE + "\n"
+                + Status.STATUS_NO_TRANSACTION + "\r\n"
+                + Status.STATUS_ACTIVE + "\r\n"
                 + Status.STATUS_NO_TRANSACTION
         );
     }
@@ -38,9 +38,9 @@ public class JtaTest {
     public void withTxRollback() throws IOException {
         String result = Request.Get("http://localhost:8080/with-tx-rollback").execute().returnContent().asString();
         assertThat(result).isEqualTo(""
-                + Status.STATUS_NO_TRANSACTION + "\n"
-                + Status.STATUS_ACTIVE + "\n"
-                + Status.STATUS_MARKED_ROLLBACK + "\n"
+                + Status.STATUS_NO_TRANSACTION + "\r\n"
+                + Status.STATUS_ACTIVE + "\r\n"
+                + Status.STATUS_MARKED_ROLLBACK + "\r\n"
                 + Status.STATUS_NO_TRANSACTION
         );
     }

--- a/javaee/servlet-jpa-jta/src/test/java/org/wildfly/swarm/ts/javaee/servlet/jpa/jta/ServletJpaJtaTest.java
+++ b/javaee/servlet-jpa-jta/src/test/java/org/wildfly/swarm/ts/javaee/servlet/jpa/jta/ServletJpaJtaTest.java
@@ -45,7 +45,7 @@ public class ServletJpaJtaTest {
     @InSequence(3)
     public void notEmpty() throws IOException {
         String result = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-        assertThat(result).isNotEmpty().isEqualTo("1 Author: Title\n");
+        assertThat(result).isNotEmpty().isEqualTo("1 Author: Title\r\n");
     }
 
     @Test

--- a/javaee8/jpa-2.2/src/test/java/org/wildfly/swarm/ts/javaee8/jpa/JpaTest.java
+++ b/javaee8/jpa-2.2/src/test/java/org/wildfly/swarm/ts/javaee8/jpa/JpaTest.java
@@ -20,7 +20,7 @@ public class JpaTest {
     @InSequence(1)
     public void createFirst() throws IOException {
         String response = Request.Post("http://localhost:8080/?year=1997&month=8&day=24&hour=12&minute=00").execute().returnContent().asString();
-        assertThat(response).isEqualTo("1: 1997-08-24 12:00, f:l\n");
+        assertThat(response).isEqualTo("1: 1997-08-24 12:00, f:l\r\n");
     }
 
     @Test
@@ -28,7 +28,7 @@ public class JpaTest {
     @InSequence(2)
     public void createSecond() throws IOException {
         String response = Request.Post("http://localhost:8080/?year=2001&month=9&day=11&hour=9&minute=3").execute().returnContent().asString();
-        assertThat(response).isEqualTo("1: 1997-08-24 12:00, f:l\n2: 2001-09-11 09:03, f:l\n");
+        assertThat(response).isEqualTo("1: 1997-08-24 12:00, f:l\r\n2: 2001-09-11 09:03, f:l\r\n");
     }
 
     @Test

--- a/microprofile/microprofile-config-1.1/src/test/java/org/wildfly/swarm/ts/microprofile/config/v11/MicroProfileConfig11Test.java
+++ b/microprofile/microprofile-config-1.1/src/test/java/org/wildfly/swarm/ts/microprofile/config/v11/MicroProfileConfig11Test.java
@@ -19,13 +19,13 @@ public class MicroProfileConfig11Test {
     public void test() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
         assertThat(response).isEqualTo(""
-                + "Value of app.timeout: 314159\n"
-                + "Value of missing.property: it's present anyway\n"
-                + "Config contains app.timeout: true\n"
-                + "Config contains missing.property: false\n"
-                + "Custom scan dir: File in custom directory\n"
-                + "YAML Property: Custom value from YAML\n"
-                + "YAML Ordered property: Property from default config source\n"
+                + "Value of app.timeout: 314159\r\n"
+                + "Value of missing.property: it's present anyway\r\n"
+                + "Config contains app.timeout: true\r\n"
+                + "Config contains missing.property: false\r\n"
+                + "Custom scan dir: File in custom directory\r\n"
+                + "YAML Property: Custom value from YAML\r\n"
+                + "YAML Ordered property: Property from default config source\r\n"
         );
     }
 }

--- a/microprofile/microprofile-config-1.3/src/test/java/org/wildfly/swarm/ts/microprofile/config/v13/MicroProfileConfig13Test.java
+++ b/microprofile/microprofile-config-1.3/src/test/java/org/wildfly/swarm/ts/microprofile/config/v13/MicroProfileConfig13Test.java
@@ -19,31 +19,31 @@ public class MicroProfileConfig13Test {
     public void test() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
         assertThat(response).isEqualTo(""
-                + "MY_ENVIRONMENT_VARIABLE: value from surefire envvar\n"
-                + "MY.ENVIRONMENT.VARIABLE: value from surefire envvar\n"
-                + "my.environment.variable: value from surefire envvar\n"
-                + "MY_ENVIRONMENT_VARIABLE: value from surefire envvar\n"
-                + "MY.ENVIRONMENT.VARIABLE: value from surefire envvar\n"
-                + "my.environment.variable: value from surefire envvar\n"
-                + "URI: http://microprofile.io\n"
-                + "Optional notExisting: false\n"
-                + "Optional existing: true\n"
-                + "my.boolean.property: true\n"
-                + "my.boolean.property: true\n"
-                + "my.int.property: 42\n"
-                + "my.int.property: 42\n"
-                + "my.long.property: 9223372036854775807\n"
-                + "my.long.property: 9223372036854775807\n"
-                + "my.float.property: 3.14\n"
-                + "my.float.property: 3.14\n"
-                + "my.double.property: 10.0\n"
-                + "my.double.property: 10.0\n"
-                + "my.stringWrapper.property: Converted stringWrapperContent\n"
-                + "my.stringWrapper.property: Converted stringWrapperContent\n"
-                + "my.animals.array.property.array: Zebra, Alligator\n"
-                + "my.animals.array.property.array: Zebra, Alligator\n"
-                + "my.animals.array.property.list: [Zebra, Alligator]\n"
-                + "my.animals.array.property.set: [Alligator, Zebra]\n"
+                + "MY_ENVIRONMENT_VARIABLE: value from surefire envvar\r\n"
+                + "MY.ENVIRONMENT.VARIABLE: value from surefire envvar\r\n"
+                + "my.environment.variable: value from surefire envvar\r\n"
+                + "MY_ENVIRONMENT_VARIABLE: value from surefire envvar\r\n"
+                + "MY.ENVIRONMENT.VARIABLE: value from surefire envvar\r\n"
+                + "my.environment.variable: value from surefire envvar\r\n"
+                + "URI: http://microprofile.io\r\n"
+                + "Optional notExisting: false\r\n"
+                + "Optional existing: true\r\n"
+                + "my.boolean.property: true\r\n"
+                + "my.boolean.property: true\r\n"
+                + "my.int.property: 42\r\n"
+                + "my.int.property: 42\r\n"
+                + "my.long.property: 9223372036854775807\r\n"
+                + "my.long.property: 9223372036854775807\r\n"
+                + "my.float.property: 3.14\r\n"
+                + "my.float.property: 3.14\r\n"
+                + "my.double.property: 10.0\r\n"
+                + "my.double.property: 10.0\r\n"
+                + "my.stringWrapper.property: Converted stringWrapperContent\r\n"
+                + "my.stringWrapper.property: Converted stringWrapperContent\r\n"
+                + "my.animals.array.property.array: Zebra, Alligator\r\n"
+                + "my.animals.array.property.array: Zebra, Alligator\r\n"
+                + "my.animals.array.property.list: [Zebra, Alligator]\r\n"
+                + "my.animals.array.property.set: [Alligator, Zebra]\r\n"
         );
     }
 
@@ -52,7 +52,7 @@ public class MicroProfileConfig13Test {
     public void testEmptyProperty() throws IOException {
         // this behavior is not spec-compliant, but empty values treatment is disputed in MP Config
         String response = Request.Get("http://localhost:8080/empty-properties").execute().returnContent().asString();
-        assertThat(response).isEqualTo("Empty system property: 'Property my.empty.system.property not found'\n"
-                + "Empty property in config file: 'Property my.empty.property.in.config.file not found'\n");
+        assertThat(response).isEqualTo("Empty system property: 'Property my.empty.system.property not found'\r\n"
+                + "Empty property in config file: 'Property my.empty.property.in.config.file not found'\r\n");
     }
 }

--- a/microprofile/microprofile-config-1.4/src/test/java/org/wildfly/swarm/ts/microprofile/config/v14/MicroProfileConfig14Test.java
+++ b/microprofile/microprofile-config-1.4/src/test/java/org/wildfly/swarm/ts/microprofile/config/v14/MicroProfileConfig14Test.java
@@ -20,12 +20,12 @@ public class MicroProfileConfig14Test {
     public void test() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
         assertThat(response).isEqualTo(""
-                + "my.byte.property: 100\n"
-                + "my.byte.property: 100\n"
-                + "my.short.property: 10000\n"
-                + "my.short.property: 10000\n"
-                + "my.char.property: Q\n"
-                + "my.char.property: Q\n"
+                + "my.byte.property: 100\r\n"
+                + "my.byte.property: 100\r\n"
+                + "my.short.property: 10000\r\n"
+                + "my.short.property: 10000\r\n"
+                + "my.char.property: Q\r\n"
+                + "my.char.property: Q\r\n"
         );
     }
 }

--- a/wildfly/cdi-config/src/test/java/org/wildfly/swarm/ts/wildfly/cdi/config/CdiConfigTest.java
+++ b/wildfly/cdi-config/src/test/java/org/wildfly/swarm/ts/wildfly/cdi/config/CdiConfigTest.java
@@ -18,6 +18,6 @@ public class CdiConfigTest {
     @RunAsClient
     public void test() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-        assertThat(response).isEqualTo("Value of app.config: FooBAR!\nConfigView contains app.config: true\n");
+        assertThat(response).isEqualTo("Value of app.config: FooBAR!\r\nConfigView contains app.config: true\r\n");
     }
 }

--- a/wildfly/hibernate-validator/src/test/java/org/wildfly/swarm/ts/wildfly/hibernate/validator/HibernateValidatorTest.java
+++ b/wildfly/hibernate-validator/src/test/java/org/wildfly/swarm/ts/wildfly/hibernate/validator/HibernateValidatorTest.java
@@ -18,6 +18,6 @@ public class HibernateValidatorTest {
     @RunAsClient
     public void test() throws IOException {
         String response = Request.Get("http://localhost:8080/").execute().returnContent().asString();
-        assertThat(response).isEqualTo("Violations: 0\nViolations: 1\n");
+        assertThat(response).isEqualTo("Violations: 0\r\nViolations: 1\r\n");
     }
 }


### PR DESCRIPTION
A lot of tests use servlet on the application side and write
a response using `println`. That previously always used `\n`
as a line separator, but UNDERTOW-1792 changed that to `\r\n`.

Considering Thorntail's lifecycle, I think it's fine to just
change all the tests to expect `\r\n` instead of `\n`.